### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/unity-build-windows.yml
+++ b/.github/workflows/unity-build-windows.yml
@@ -29,7 +29,7 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}

--- a/.github/workflows/unity-build-windows.yml
+++ b/.github/workflows/unity-build-windows.yml
@@ -15,11 +15,11 @@ jobs:
         targetPlatform:
           - StandaloneWindows64 # Build a Windows 64-bit standalone.
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           lfs: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: Library
           key: Library-${{ matrix.targetPlatform }}
@@ -29,7 +29,7 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}


### PR DESCRIPTION
### Pull Request Description

This pull request updates the GitHub Actions used in the Unity build workflow to their latest versions. The changes include:

- Upgrading the `checkout` action to v3
- Upgrading the `cache` action to v3
- Upgrading the `upload-artifact` action to v3

These updates aim to enhance the performance and security of the workflow. By utilizing the latest versions of these actions, we can ensure a more efficient and reliable CI/CD process. 

Please review the changes and let me know if there are any questions or further modifications needed.