### PR TITLE
feat: add unit death event and improve projectile behavior

### DIFF
--- a/Assets/Prefabs/Arrow.prefab
+++ b/Assets/Prefabs/Arrow.prefab
@@ -4895,6 +4895,9 @@ ParticleSystemRenderer:
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4933,13 +4936,15 @@ ParticleSystemRenderer:
   m_RenderAlignment: 0
   m_Pivot: {x: 0.5, y: 0, z: 0}
   m_Flip: {x: 1, y: 0, z: 0}
-  m_UseCustomVertexStreams: 1
   m_EnableGPUInstancing: 1
   m_ApplyActiveColorSpace: 0
   m_AllowRoll: 1
   m_FreeformStretching: 0
   m_RotateWithStretchDirection: 1
+  m_UseCustomVertexStreams: 1
   m_VertexStreams: 000103041f
+  m_UseCustomTrailVertexStreams: 0
+  m_TrailVertexStreams: 00010304
   m_Mesh: {fileID: 1825875415147931077, guid: 45145197eb6c06f46b232506fcc4cac6, type: 3}
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
@@ -4963,7 +4968,7 @@ GameObject:
   - component: {fileID: 5955218331064883769}
   - component: {fileID: 2649799684166538073}
   - component: {fileID: 5154916980072432605}
-  - component: {fileID: -5676189377895650237}
+  - component: {fileID: -5544415194795067568}
   m_Layer: 0
   m_Name: Arrow
   m_TagString: Untagged
@@ -5092,7 +5097,7 @@ MonoBehaviour:
   serverOnly: 0
   visible: 0
   hasSpawned: 0
---- !u!114 &-5676189377895650237
+--- !u!114 &-5544415194795067568
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5101,31 +5106,20 @@ MonoBehaviour:
   m_GameObject: {fileID: 5955218331064883768}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8ff3ba0becae47b8b9381191598957c8, type: 3}
+  m_Script: {fileID: 11500000, guid: 83392ae5c1b731446909f252fd494ae4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncDirection: 0
   syncMode: 0
   syncInterval: 0
-  target: {fileID: 5955218331064883773}
+  target: {fileID: 3990106352879761730}
   clientAuthority: 0
-  syncPosition: 1
-  syncRotation: 1
-  syncScale: 0
-  interpolatePosition: 1
-  interpolateRotation: 1
-  interpolateScale: 1
-  sendIntervalMultiplier: 1
-  timelineOffset: 0
-  showGizmos: 0
-  showOverlay: 0
-  overlayColor: {r: 0, g: 0, b: 0, a: 0.5}
-  onlySyncOnChange: 1
-  onlySyncOnChangeCorrectionMultiplier: 2
-  rotationSensitivity: 0.01
-  compressRotation: 0
-  positionPrecision: 0.01
-  scalePrecision: 0.01
+  syncVelocity: 1
+  clearVelocity: 0
+  velocitySensitivity: 0.1
+  syncAngularVelocity: 1
+  clearAngularVelocity: 0
+  angularVelocitySensitivity: 0.1
 --- !u!1 &8119805822482602601
 GameObject:
   m_ObjectHideFlags: 0
@@ -5167,9 +5161,8 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8119805822482602601}
   m_Enabled: 1
-  serializedVersion: 10
+  serializedVersion: 11
   m_Type: 2
-  m_Shape: 0
   m_Color: {r: 0.49803922, g: 0, b: 0, a: 1}
   m_Intensity: 0.5
   m_Range: 4
@@ -5219,8 +5212,12 @@ Light:
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
 --- !u!114 &1620182030
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5302,6 +5299,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -5336,7 +5336,7 @@ PrefabInstance:
     m_TransformParent: {fileID: 5955218331064883773}
     m_Modifications:
     - target: {fileID: 215341878657952436, guid: f3bd82d9c77367d4c970a9795c4f15c7, type: 3}
-      propertyPath: m_Materials.Array.data[0]
+      propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 3f59f39fe3cbe7542b9d32e46a71cdac, type: 2}
     - target: {fileID: 1348300943886897627, guid: f3bd82d9c77367d4c970a9795c4f15c7, type: 3}

--- a/Assets/Scripts/Events/GameEvent.cs
+++ b/Assets/Scripts/Events/GameEvent.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+#nullable enable
 
 namespace MyGame.Events
 {
@@ -60,6 +60,18 @@ namespace MyGame.Events
         {
             Unit = unit;
             ShieldAmount = shieldAmount;
+        }
+    }
+
+    public class UnitDiedEvent : GameEvent
+    {
+        public UnitController Unit { get; }
+        public UnitController? Killer { get; }
+
+        public UnitDiedEvent(UnitController unit, UnitController? killer = null)
+        {
+            Unit = unit;
+            Killer = killer;
         }
     }
 

--- a/Assets/Scripts/FloatingDamageTextManager.cs
+++ b/Assets/Scripts/FloatingDamageTextManager.cs
@@ -1,5 +1,4 @@
 using MyGame.Events;
-using Unity.VisualScripting;
 using UnityEngine;
 
 public class FloatingDamageTextManager : MonoBehaviour

--- a/Assets/Scripts/Projectiles/ProjectileController.cs
+++ b/Assets/Scripts/Projectiles/ProjectileController.cs
@@ -20,16 +20,30 @@ public class ProjectileController : NetworkBehaviour
     private Vector3 spawn;
 
     private bool hasCollidedWithUnit;
+
+
+    Rigidbody rb;
     
 
     // Called when the projectile is spawned
     void OnEnable()
     {
+        rb = GetComponent<Rigidbody>();
         spawn = transform.position;
+        if(isServer) {
+            ApplyForce();
+        }
+    }
+
+    void FixedUpdate()
+    {
+        if(isServer) {
+            ApplyForce();
+        }
     }
 
     // Called every frame
-    void FixedUpdate()
+    void LateUpdate()
     {
         if (isServer) {
             MoveProjectile();
@@ -37,10 +51,19 @@ public class ProjectileController : NetworkBehaviour
     }
 
     [Server]
+    void ApplyForce()
+    {
+        if (rb != null)
+        {
+            rb.linearVelocity = transform.forward * speed;
+        }
+    }
+
+    [Server]
     void MoveProjectile()
     {
         // Move the projectile
-        transform.position += transform.forward * speed * Time.fixedDeltaTime;
+        // transform.position += transform.forward * speed * Time.fixedDeltaTime;
 
         var distanceTravelled = Vector3.Distance(spawn, transform.position);
 

--- a/Assets/Scripts/Units/UnitController.cs
+++ b/Assets/Scripts/Units/UnitController.cs
@@ -142,6 +142,7 @@ public class UnitController : NetworkBehaviour
         if (Health <= 0)
         {
             RaiseOnKillEvent(attacker, this);
+            EventManager.Instance.Publish(new UnitDiedEvent(this, attacker));   
         }
     }
 


### PR DESCRIPTION
Add a new event for unit death to enhance gameplay feedback. 
Refactor projectile movement to utilize Rigidbody for better 
physics interactions and ensure consistent behavior across 
server instances. Update Arrow prefab properties for 
optimization and clarity.