### PR TITLE
feat: implement unit gold drop and event handling

### DIFF
--- a/Assets/Icons/gold-coin.asset
+++ b/Assets/Icons/gold-coin.asset
@@ -90,8 +90,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 868
       m_Height: 868
-      m_HorizontalBearingX: -86.8
-      m_HorizontalBearingY: 781.2
+      m_HorizontalBearingX: 90.8
+      m_HorizontalBearingY: 769.8
       m_HorizontalAdvance: 868
     m_GlyphRect:
       m_X: 6

--- a/Assets/Icons/gold-coin.png.meta
+++ b/Assets/Icons/gold-coin.png.meta
@@ -104,8 +104,8 @@ TextureImporter:
         y: 6
         width: 868
         height: 868
-      alignment: 9
-      pivot: {x: 0.1, y: 0.1}
+      alignment: 6
+      pivot: {x: 0, y: 0}
       border: {x: 0, y: 0, z: 0, w: 0}
       customData: 
       outline: []

--- a/Assets/Prefabs/FloatingDamageText.prefab
+++ b/Assets/Prefabs/FloatingDamageText.prefab
@@ -103,7 +103,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 100 <sprite name="gold_coin">
+  m_text: 100<sprite name="gold_coin">
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: e73a58f6e2794ae7b1b7e50b7fb811b0, type: 2}

--- a/Assets/Scripts/Events/GameEvent.cs
+++ b/Assets/Scripts/Events/GameEvent.cs
@@ -84,4 +84,30 @@ namespace MyGame.Events
             PlayerCharacter = playerCharacter;
         }
     }
+
+    public class UnitDroppedGoldEvent : GameEvent
+    {
+        public UnitController Unit { get; }
+        public int GoldAmount { get; }
+
+        public UnitController? Killer { get; }
+        public UnitDroppedGoldEvent(UnitController unit, int goldAmount, UnitController? killer = null)
+        {
+            Unit = unit;
+            GoldAmount = goldAmount;
+            Killer = killer;
+        }
+    }
+
+    public class PlayerReceivedGoldEvent : GameEvent
+    {
+        public UnitController Player { get; }
+        public int GoldAmount { get; }
+
+        public PlayerReceivedGoldEvent(UnitController player, int goldAmount)
+        {
+            Player = player;
+            GoldAmount = goldAmount;
+        }
+    }
 }

--- a/Assets/Scripts/FloatingDamageTextManager.cs
+++ b/Assets/Scripts/FloatingDamageTextManager.cs
@@ -22,7 +22,7 @@ public class FloatingDamageTextManager : MonoBehaviour
         EventManager.Instance.Subscribe<UnitHealedEvent>(OnUnitHealed);
         EventManager.Instance.Subscribe<UnitShieldedEvent>(OnUnitShielded);
         EventManager.Instance.Subscribe<MyPlayerUnitSpawnedEvent>(OnMyPlayerUnitSpawned);
-        EventManager.Instance.Subscribe<UnitDiedEvent>(OnUnitDied);
+        EventManager.Instance.Subscribe<UnitDroppedGoldEvent>(OnUnitDroppedGold);
     }
 
     void OnDisable()
@@ -31,7 +31,7 @@ public class FloatingDamageTextManager : MonoBehaviour
         EventManager.Instance.Unsubscribe<UnitHealedEvent>(OnUnitHealed);
         EventManager.Instance.Unsubscribe<UnitShieldedEvent>(OnUnitShielded);
         EventManager.Instance.Unsubscribe<MyPlayerUnitSpawnedEvent>(OnMyPlayerUnitSpawned);
-        EventManager.Instance.Unsubscribe<UnitDiedEvent>(OnUnitDied);
+        EventManager.Instance.Unsubscribe<UnitDroppedGoldEvent>(OnUnitDroppedGold);
     }
 
     public void OnUnitDamaged(UnitDamagedEvent unitDamagedEvent)
@@ -64,12 +64,12 @@ public class FloatingDamageTextManager : MonoBehaviour
         }
     }
 
-    public void OnUnitDied(UnitDiedEvent unitDiedEvent)
+    public void OnUnitDroppedGold(UnitDroppedGoldEvent unitDroppedGoldEvent)
     {
-        var hasMyUnitedKilledTheUnit = unitDiedEvent.Killer == myPlayerUnitController;
+        var hasMyUnitedKilledTheUnit = unitDroppedGoldEvent.Killer == myPlayerUnitController;
         if (hasMyUnitedKilledTheUnit)
         {
-            SpawnDamageText("+14 <sprite name=\"gold_coin\">", 14, unitDiedEvent.Unit.transform, yellowColor);
+            SpawnDamageText($"+{unitDroppedGoldEvent.GoldAmount}<sprite name=\"gold_coin\">", unitDroppedGoldEvent.GoldAmount, unitDroppedGoldEvent.Unit.transform, yellowColor);
         }
     }
 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -96,6 +96,7 @@ public class PlayerController : NetworkBehaviour
         NetworkServer.Spawn(unit);
         Unit = unit;
         _unitController = Unit.GetComponent<UnitController>();
+        _unitController.unitType = UnitType.Player;
     }
 
     [Client]


### PR DESCRIPTION
Add event subscription for unit death and gold drop in the game manager.  Introduce `UnitDroppedGoldEvent` to handle gold drops when units die.  Update floating damage text to reflect gold amounts.  Set unit types for player and zombie units. 
Refactor damage handling to improve event management.