### PR TITLE
fix: prevent subscription on non-server

### DIFF
--- a/Assets/Scripts/ZombieGameManager.cs
+++ b/Assets/Scripts/ZombieGameManager.cs
@@ -34,11 +34,13 @@ public class ZombieGameManager : NetworkBehaviour
 
     void OnEnable()
     {
+        if (!isServer) return;
         EventManager.Instance.Subscribe<UnitDiedEvent>(OnUnitDied);   
     }
 
     void OnDisable()
     {
+        if (!isServer) return;
         EventManager.Instance.Unsubscribe<UnitDiedEvent>(OnUnitDied);   
     }
 


### PR DESCRIPTION
Add server in OnEnable andDisable methods to ensure that  event subscriptions only occur on server instances. This prevents  unnecessary operations and potential errors in non-server contexts.