### PR TITLE
feat: rename event class and add gold management methods

### DIFF
--- a/Assets/Scripts/Events/GameEvent.cs
+++ b/Assets/Scripts/Events/GameEvent.cs
@@ -99,12 +99,12 @@ namespace MyGame.Events
         }
     }
 
-    public class PlayerReceivedGoldEvent : GameEvent
+    public class PlayerReceivesGoldEvent : GameEvent
     {
         public UnitController Player { get; }
         public int GoldAmount { get; }
 
-        public PlayerReceivedGoldEvent(UnitController player, int goldAmount)
+        public PlayerReceivesGoldEvent(UnitController player, int goldAmount)
         {
             Player = player;
             GoldAmount = goldAmount;

--- a/Assets/Scripts/ZombieGameManager.cs
+++ b/Assets/Scripts/ZombieGameManager.cs
@@ -162,7 +162,7 @@ public class ZombieGameManager : NetworkBehaviour
         int amount = 10;
         EventManager.Instance.Publish(new UnitDroppedGoldEvent(zombie, amount, killer));
         RpcZombieDroppedGold(amount, zombie, killer);
-        EventManager.Instance.Publish(new PlayerReceivedGoldEvent(killer, amount));
+        EventManager.Instance.Publish(new PlayerReceivesGoldEvent(killer, amount));
         RpcPlayerReceivedGold(amount, killer);
     }
 
@@ -177,6 +177,6 @@ public class ZombieGameManager : NetworkBehaviour
     public void RpcPlayerReceivedGold(int amount, UnitController player)
     {
         if (isServer) return;
-        EventManager.Instance.Publish(new PlayerReceivedGoldEvent(player, amount));
+        EventManager.Instance.Publish(new PlayerReceivesGoldEvent(player, amount));
     }
 }


### PR DESCRIPTION
Renames `PlayerReceivedGoldEvent` to `PlayerReceivesGoldEvent` for  consistency. Adds methods to `PlayerController` for managing gold:  `AddGold` to increase gold and `SpendGold` to decrease it if enough  gold is available. Updates event subscriptions and handling to reflect  the new event name and ensure proper gold management during gameplay.