### PR TITLE
feat(ui): enhance zombie game UI with round and wave labels

### DIFF
--- a/Assets/Scenes/ZombyGameScene.unity
+++ b/Assets/Scenes/ZombyGameScene.unity
@@ -15759,6 +15759,7 @@ Transform:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
+  - {fileID: 854878786}
   - {fileID: 146265055}
   - {fileID: 59859921}
   - {fileID: 864273879}
@@ -15767,5 +15768,4 @@ SceneRoots:
   - {fileID: 730377713}
   - {fileID: 154434317}
   - {fileID: 871623064}
-  - {fileID: 854878786}
   - {fileID: 2037798482}

--- a/Assets/Scripts/UiDocumentZombieIngameController.cs
+++ b/Assets/Scripts/UiDocumentZombieIngameController.cs
@@ -1,31 +1,69 @@
+using System.Collections;
+using MyGame.Events;
 using UnityEngine;
 using UnityEngine.UIElements;
 
 public class UiDocumentZombieIngameController : MonoBehaviour
 {
-    public ZombieGameManager ZombieGameManager;
     private UIDocument _uiDocument;
     private Label _labelWave;
+    private Label _labelRoundStarted;
     void Awake()
     {
         _uiDocument = GetComponent<UIDocument>();
         _labelWave = _uiDocument.rootVisualElement.Q<Label>(name: "labelWave");
-    }
-    void Start()
-    {
-        var currentWave = ZombieGameManager.currentWave;
-        if (currentWave > 0)
-        {
-            _labelWave.text = ZombieGameManager.currentWave.ToString();
-        } else
-        {
-            _labelWave.text = "";
-        }
-        ZombieGameManager.OnNewWaveStarted += HandleOnNewWaveStarted;
+        _labelRoundStarted = _uiDocument.rootVisualElement.Q<Label>(name: "labelRoundStarted");
+        _labelWave.text = "";
+        _labelRoundStarted.text = "";
     }
 
-    void HandleOnNewWaveStarted(int wave)
+    void Start()
     {
-        _labelWave.text = wave.ToString();
+        EventManager.Instance.Subscribe<WaveStartedEvent>(OnWaveStartedEvent);
+    }
+
+    void OnDestroy()
+    {
+        EventManager.Instance.Unsubscribe<WaveStartedEvent>(OnWaveStartedEvent);
+    }
+
+    void OnWaveStartedEvent(WaveStartedEvent waveStartedEvent)
+    {
+        Debug.Log($"Wave {waveStartedEvent.WaveNumber} started with {waveStartedEvent.TotalZombies} zombies.");
+        _labelWave.text = waveStartedEvent.WaveNumber.ToString();
+        _labelRoundStarted.text = $"Round\n{waveStartedEvent.WaveNumber}";
+        _labelRoundStarted.style.opacity = 1f;
+        StartCoroutine(FadeText(_labelRoundStarted, 0f, 1f, 1f)); // Fade in
+        StartCoroutine(WaitAndFadeOut(_labelRoundStarted, 1f, 3f)); // Wait and fade out
+    }
+
+    IEnumerator FadeText(Label textLabel, float startAlpha, float endAlpha, float duration)
+    {
+        float elapsedTime = 0f;
+        while (elapsedTime < duration)
+        {
+            float newAlpha = Mathf.Lerp(startAlpha, endAlpha, elapsedTime / duration);
+            textLabel.style.opacity = newAlpha;
+            elapsedTime += Time.deltaTime;
+            yield return null;
+        }
+        textLabel.style.opacity = endAlpha;
+    }
+
+    IEnumerator WaitAndFadeOut(Label textLabel, float waitTime, float fadeDuration)
+    {
+        yield return new WaitForSeconds(waitTime);
+        float elapsedTime = 0f;
+        float startAlpha = textLabel.style.opacity.value;
+        float endAlpha = 0f;
+
+        while (elapsedTime < fadeDuration)
+        {
+            float newAlpha = Mathf.Lerp(startAlpha, endAlpha, elapsedTime / fadeDuration);
+            textLabel.style.opacity = newAlpha;
+            elapsedTime += Time.deltaTime;
+            yield return null;
+        }
+        textLabel.style.opacity = endAlpha;
     }
 }

--- a/Assets/Ui/UiZombieIngame.uxml
+++ b/Assets/Ui/UiZombieIngame.uxml
@@ -1,4 +1,8 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <ui:VisualElement style="flex-grow: 1; background-color: rgba(0, 0, 0, 0);" />
-    <ui:Label tabindex="-1" text="1" display-tooltip-when-elided="true" name="labelWave" style="-unity-font-style: bold-and-italic; font-size: 72px; padding-left: 12px; padding-bottom: 8px; color: rgb(106, 0, 0);" />
+    <ui:VisualElement name="VisualElement" style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); flex-basis: 50%; align-items: center; justify-content: center;">
+        <ui:Label text="Round 1" name="labelRoundStarted" style="white-space: nowrap; -unity-text-align: upper-center; font-size: 70px; -unity-font-style: bold; color: rgb(255, 255, 255);" />
+    </ui:VisualElement>
+    <ui:VisualElement name="VisualElement" style="flex-grow: 1; flex-direction: column-reverse; flex-basis: 50%;">
+        <ui:Label tabindex="-1" text="1" display-tooltip-when-elided="true" name="labelWave" style="-unity-font-style: bold-and-italic; font-size: 72px; padding-left: 12px; padding-bottom: 8px; color: rgb(106, 0, 0);" />
+    </ui:VisualElement>
 </ui:UXML>


### PR DESCRIPTION
Add new visual elements for displaying the current round and wave  number in the zombie game UI. Update the UXML layout to include  these elements and modify the controller to handle wave start  events, updating the labels accordingly. Implement fade-in and  fade-out effects for the round label to improve user experience.