### PR TITLE
feat: add zombie damage handling and gold drop logic

### DIFF
--- a/Assets/Prefabs/Arrow.prefab
+++ b/Assets/Prefabs/Arrow.prefab
@@ -5040,10 +5040,10 @@ CapsuleCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.5
+  m_Radius: 0.25
   m_Height: 2
   m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 0, z: 0.25}
 --- !u!114 &5955218331064883769
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Unit.prefab
+++ b/Assets/Prefabs/Unit.prefab
@@ -572,6 +572,7 @@ MonoBehaviour:
   moveSpeed: 5
   Race: 0
   weapon: {fileID: 947192566}
+  unitType: 0
 --- !u!114 &8405535932912576057
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -618,7 +619,7 @@ MonoBehaviour:
   IsAttacking: 0
   projectile: {fileID: 11400000, guid: 196370f6a0a8f4846a3a154ca9f64484, type: 2}
   projectileSpeed: 22
-  spawnDistance: 1.2
+  spawnDistance: 1
 --- !u!114 &-3108773104642818051
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1407,6 +1408,10 @@ PrefabInstance:
     - target: {fileID: 145326, guid: 91a56ed4bbd7cea42b402e691f87d555, type: 3}
       propertyPath: m_Layer
       value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 145326, guid: 91a56ed4bbd7cea42b402e691f87d555, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 145586, guid: 91a56ed4bbd7cea42b402e691f87d555, type: 3}
       propertyPath: m_Layer


### PR DESCRIPTION
Implement OnUnitDamagedEvent to handle damage to zombies and 
reward players with gold. Update ZombieDropGold to accept 
dynamic gold amounts. Adjust prefab properties for unit 
spawn distance and collider dimensions for better gameplay 
balance. Subscribe and unsubscribe to new events in the 
ZombieGameManager.