### PR TITLE
refactor: remove debug log from wave start event

### DIFF
--- a/Assets/Scripts/UiDocumentZombieIngameController.cs
+++ b/Assets/Scripts/UiDocumentZombieIngameController.cs
@@ -42,7 +42,6 @@ public class UiDocumentZombieIngameController : MonoBehaviour
 
     void OnWaveStartedEvent(WaveStartedEvent waveStartedEvent)
     {
-        Debug.Log($"Wave {waveStartedEvent.WaveNumber} started with {waveStartedEvent.TotalZombies} zombies.");
         _labelWave.text = waveStartedEvent.WaveNumber.ToString();
         _labelRoundStarted.text = $"Round\n{waveStartedEvent.WaveNumber}";
         _labelRoundStarted.style.opacity = 1f;


### PR DESCRIPTION
Eliminate the debug log statement in the OnWaveStartedEvent 
method to clean up the console output during gameplay. This 
improves performance and reduces unnecessary logging.