### PR TITLE
fix(material): adjust dissolve and texture speeds for balance

### DIFF
--- a/Assets/Fx/TrailShadowLight.mat
+++ b/Assets/Fx/TrailShadowLight.mat
@@ -55,13 +55,13 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
-    - _DissolveScale: 100
+    - _DissolveScale: 25
     - _QueueControl: 0
     - _QueueOffset: 0
     m_Colors:
     - _Color01: {r: 0.9528302, g: 0.12135102, b: 0.12135102, a: 0}
     - _Color02: {r: 0.09433961, g: 0.02002492, b: 0.02002492, a: 0}
-    - _DissolveSpeed: {r: 20, g: 0, b: 0, a: 0}
-    - _MainTextureSpeed: {r: -1, g: 0, b: 0, a: 0}
+    - _DissolveSpeed: {r: -0.5, g: 0, b: 0, a: 0}
+    - _MainTextureSpeed: {r: -0.5, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1


### PR DESCRIPTION
Reduce the _DissolveScale from 100 to 25 to enhance visual 
subtlety. Modify _DissolveSpeed and _MainTextureSpeed from 
{r: 20, g: 0, b: 0, a: 0} and {r: -1, g: 0, b: 0, a: 0} 
to {r: -0.5, g: 0, b: 0, a: 0} for improved animation 
smoothness and consistency in the material's behavior.