### PR TITLE
fix: update zombie team assignment to neutral

### DIFF
--- a/Assets/Ressources/ScriptableObjects/Zombie.asset
+++ b/Assets/Ressources/ScriptableObjects/Zombie.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   unitName: zombie
   unitType: 1
-  team: 2
+  team: 0
   health: 25
   maxHealth: 25
   shield: 0


### PR DESCRIPTION
Change the zombie team assignment from 2 to 0 to reflect a neutral 
alignment. This adjustment ensures that zombies do not belong to a 
specific team, allowing for more flexible gameplay dynamics.