### PR TITLE
refactor: standardize health variable naming

### DIFF
--- a/Assets/Prefabs/Unit.prefab
+++ b/Assets/Prefabs/Unit.prefab
@@ -562,6 +562,9 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0
+  unitType: 0
+  team: 0
+  unitName: 
   horizontalInput: 0
   verticalInput: 0
   angle: 0
@@ -572,7 +575,6 @@ MonoBehaviour:
   moveSpeed: 5
   Race: 0
   weapon: {fileID: 947192566}
-  unitType: 0
 --- !u!114 &8405535932912576057
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/UnitSpawner.cs
+++ b/Assets/Scripts/UnitSpawner.cs
@@ -35,7 +35,7 @@ public class UnitSpawner : NetworkBehaviour
 
         if (unitController != null)
         {
-            unitController.Health = unitData.health;
+            unitController.health = unitData.health;
             unitController.maxHealth = unitData.maxHealth;
             unitController.shield = unitData.shield;
             unitController.maxShield = unitData.maxShield;

--- a/Assets/Scripts/UnitUiController.cs
+++ b/Assets/Scripts/UnitUiController.cs
@@ -31,7 +31,7 @@ public class UnitUiController : MonoBehaviour
         {
             DisableShieldbar();
         }
-        if (_unitController.Health == 0)
+        if (_unitController.health == 0)
         {
             DisableGuiElements();
         }

--- a/Assets/Units/Animations/UnitAnimationController.cs
+++ b/Assets/Units/Animations/UnitAnimationController.cs
@@ -30,12 +30,9 @@ public class UnitAnimationController : NetworkBehaviour
 
     void Update()
     {
-        if (!isClient) return;
-        
         HandleMovementAnimation();
     }
 
-    [Client]
     private void HandleMovementAnimation () {
         float horizontal = unitController.horizontalInput;
         float vertical = unitController.verticalInput;


### PR DESCRIPTION
Rename `Health` to `health` for consistency across the 
`UnitController` class. Update related methods to use the 
new variable name. This change improves code readability 
and maintains a uniform naming convention throughout the 
script. Additionally, remove unnecessary event calls to 
streamline damage handling logic.