### PR TITLE
refactor: remove unused namespace from UnitController

### DIFF
--- a/Assets/Scripts/UnitController.cs
+++ b/Assets/Scripts/UnitController.cs
@@ -1,7 +1,6 @@
 using System;
 using Mirror;
 using MyGame.Events;
-using Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering;
 using UnityEngine;
 
 public class UnitController : NetworkBehaviour


### PR DESCRIPTION
Eliminate the unused `Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering` 
namespace from `UnitController.cs` to clean up the code and improve 
readability. This change helps maintain a tidy codebase by removing 
unnecessary dependencies.