### PR TITLE
feat: update unit model assignment in UnitSpawner

### DIFF
--- a/Assets/Resources/ScriptableObjects/Units/Player.asset
+++ b/Assets/Resources/ScriptableObjects/Units/Player.asset
@@ -21,3 +21,4 @@ MonoBehaviour:
   maxShield: 50
   moveSpeed: 5
   weapon: {fileID: 11400000, guid: c8313ed289195d541a854ac0e7c818f8, type: 2}
+  modelData: {fileID: 11400000, guid: a3f4d6ab735ff504596c56b77d84e23c, type: 2}

--- a/Assets/Resources/ScriptableObjects/Units/Zombie.asset
+++ b/Assets/Resources/ScriptableObjects/Units/Zombie.asset
@@ -21,3 +21,4 @@ MonoBehaviour:
   maxShield: 0
   moveSpeed: 3
   weapon: {fileID: 11400000, guid: 5a821e469598a924a8ada0962153e09a, type: 2}
+  modelData: {fileID: 11400000, guid: a3f4d6ab735ff504596c56b77d84e23c, type: 2}

--- a/Assets/Scripts/ScriptableObjects/UnitData.cs
+++ b/Assets/Scripts/ScriptableObjects/UnitData.cs
@@ -16,4 +16,7 @@ public class UnitData : ScriptableObject
 
     [Header("Weapon")]
     public WeaponData weapon;
+
+    [Header("Model")]
+    public ModelData modelData;
 }

--- a/Assets/Scripts/UnitSpawner.cs
+++ b/Assets/Scripts/UnitSpawner.cs
@@ -44,7 +44,7 @@ public class UnitSpawner : NetworkBehaviour
             unitController.unitName = unitData.unitName;
             unitController.weaponName = unitData.weapon.weaponName;
             unitController.currentWeapon = unitData.weapon;
-            unitController.EquipModel("zombie"); // Example model name, replace with actual model name
+            unitController.EquipModel(unitData.modelData.modelName);
         }
 
         NetworkServer.Spawn(unitInstance);


### PR DESCRIPTION
Update the UnitSpawner to dynamically assign the model name from 
unitData instead of using a hardcoded value. Add modelData field 
to UnitData to support this change. Include modelData in Player 
and Zombie ScriptableObjects to ensure proper model assignment 
for each unit type.