### PR TITLE
fix: update resource IDs in UniversalRenderPipeline settings

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform.meta
+++ b/Assets/Mirror/Components/NetworkTransform.meta
@@ -1,3 +1,3 @@
 fileFormatVersion: 2
-guid: 36de72d9255741659bcbd1971ed29822
+guid: e1f7b32bb7542412289bc007f4c34832
 timeCreated: 1668358590

--- a/Assets/PolygonDungeon/URP_ExtractMe.unitypackage.meta
+++ b/Assets/PolygonDungeon/URP_ExtractMe.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 86822c3af37839b49ab77b717dd178c2
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Renderer/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/Renderer/UniversalRenderPipelineGlobalSettings.asset
@@ -33,28 +33,28 @@ MonoBehaviour:
   m_Settings:
     m_SettingsList:
       m_List:
-      - rid: 7542123255638786144
-      - rid: 7542123255638786145
+      - rid: 6774301312907739205
+      - rid: 6774301312907739206
       - rid: 4698170347409375234
       - rid: 4698170347409375235
       - rid: 4698170347409375236
       - rid: 4698170347409375237
       - rid: 4698170347409375238
-      - rid: 7542123255638786146
+      - rid: 6774301312907739207
       - rid: 4698170347409375240
       - rid: 4698170347409375241
-      - rid: 7542123255638786147
-      - rid: 7542123255638786148
-      - rid: 7542123255638786149
+      - rid: 6774301312907739208
+      - rid: 6774301312907739209
+      - rid: 6774301312907739210
       - rid: 4698170347409375245
-      - rid: 7542123255638786150
-      - rid: 7542123255638786151
-      - rid: 7542123255638786152
+      - rid: 6774301312907739211
+      - rid: 6774301312907739212
+      - rid: 6774301312907739213
       - rid: 4698170347409375249
-      - rid: 7542123255638786153
-      - rid: 7542123255638786154
+      - rid: 6774301312907739214
+      - rid: 6774301312907739215
       - rid: 4698170347409375252
-      - rid: 7542123255638786155
+      - rid: 6774301312907739216
     m_RuntimeSettings:
       m_List:
       - rid: 4698170347409375234
@@ -164,11 +164,11 @@ MonoBehaviour:
         m_ExportShaderVariants: 1
         m_ShaderVariantLogLevel: 0
         m_StripRuntimeDebugShaders: 1
-    - rid: 7542123255638786144
+    - rid: 6774301312907739205
       type: {class: UniversalRenderPipelineEditorAssets, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultSettingsVolumeProfile: {fileID: 11400000, guid: eda47df5b85f4f249abf7abd73db2cb2, type: 2}
-    - rid: 7542123255638786145
+    - rid: 6774301312907739206
       type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
@@ -177,7 +177,7 @@ MonoBehaviour:
         m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
         m_DefaultSpriteMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-    - rid: 7542123255638786146
+    - rid: 6774301312907739207
       type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
@@ -189,14 +189,14 @@ MonoBehaviour:
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 7542123255638786147
+    - rid: 6774301312907739208
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
         m_StripUnusedPostProcessingVariants: 0
         m_StripUnusedVariants: 1
         m_StripScreenCoordOverrideVariants: 1
-    - rid: 7542123255638786148
+    - rid: 6774301312907739209
       type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
@@ -211,7 +211,7 @@ MonoBehaviour:
         m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
         m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
         m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
-    - rid: 7542123255638786149
+    - rid: 6774301312907739210
       type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
       data:
         m_Version: 0
@@ -224,21 +224,21 @@ MonoBehaviour:
         m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
         m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
         m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 7542123255638786150
+    - rid: 6774301312907739211
       type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         probeVolumeBlendStatesCS: {fileID: 7200000, guid: a3f7b8c99de28a94684cb1daebeccf5d, type: 3}
         probeVolumeUploadDataCS: {fileID: 7200000, guid: 0951de5992461754fa73650732c4954c, type: 3}
         probeVolumeUploadDataL2CS: {fileID: 7200000, guid: 6196f34ed825db14b81fb3eb0ea8d931, type: 3}
-    - rid: 7542123255638786151
+    - rid: 6774301312907739212
       type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_version: 0
         m_IncludeReferencedInScenes: 0
         m_IncludeAssetsByLabel: 0
         m_LabelToInclude: 
-    - rid: 7542123255638786152
+    - rid: 6774301312907739213
       type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -251,7 +251,7 @@ MonoBehaviour:
         skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
         renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
         renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 7542123255638786153
+    - rid: 6774301312907739214
       type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -261,12 +261,12 @@ MonoBehaviour:
         probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
         probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
         numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 7542123255638786154
+    - rid: 6774301312907739215
       type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         m_ProbeVolumeDisableStreamingAssets: 0
-    - rid: 7542123255638786155
+    - rid: 6774301312907739216
       type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}


### PR DESCRIPTION
Update resource IDs in the UniversalRenderPipelineGlobalSettings.asset 
to ensure compatibility with the latest asset references. This change 
replaces outdated IDs with new ones, maintaining the integrity of the 
render pipeline configuration and preventing potential runtime issues. 
Additionally, remove the obsolete URP_ExtractMe.unitypackage.meta file 
to clean up the project structure.