### PR TITLE
fix(weapon): prevent attack if attacker is null or dead

### DIFF
--- a/Assets/Scripts/WeaponController.cs
+++ b/Assets/Scripts/WeaponController.cs
@@ -33,6 +33,8 @@ public class WeaponController : NetworkBehaviour
         var delay = weaponData.attackTime * 1000;
         await Task.Delay((int)delay);
 
+        if (attacker == null || attacker.IsDead) return;
+        
         weaponData.PerformAttack(attacker);
         attacker.moveSpeed = originalSpeed;
         isAttacking = false;


### PR DESCRIPTION
Add a check to ensure the attacker is not null and is alive before 
performing an attack. This prevents potential null reference errors 
and ensures that the attack logic only executes for valid targets.