### PR TITLE
feat: add Zombie Crawler unit and animations

### DIFF
--- a/Assets/Animations/Scary Zombie Pack/running crawl.fbx.meta
+++ b/Assets/Animations/Scary Zombie Pack/running crawl.fbx.meta
@@ -42,8 +42,8 @@ ModelImporter:
       cycleOffset: 0
       loop: 0
       hasAdditiveReferencePose: 0
-      loopTime: 0
-      loopBlend: 0
+      loopTime: 1
+      loopBlend: 1
       loopBlendOrientation: 0
       loopBlendPositionY: 0
       loopBlendPositionXZ: 0

--- a/Assets/Resources/ScriptableObjects/AnimationSets/HumanoidZombieCrawlerUnarmed.asset
+++ b/Assets/Resources/ScriptableObjects/AnimationSets/HumanoidZombieCrawlerUnarmed.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b36c5779a50d426893bb81edb750fed, type: 3}
+  m_Name: HumanoidZombieCrawlerUnarmed
+  m_EditorClassIdentifier: 
+  animatorController: {fileID: 22100000, guid: bfa276def84894d1c9fbec1fce1dcdcc, type: 2}

--- a/Assets/Resources/ScriptableObjects/AnimationSets/HumanoidZombieCrawlerUnarmed.asset.meta
+++ b/Assets/Resources/ScriptableObjects/AnimationSets/HumanoidZombieCrawlerUnarmed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f4787dc5493b2491bbad0b72c6dd2f6d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/ModelDatabase.asset
+++ b/Assets/Resources/ScriptableObjects/ModelDatabase.asset
@@ -15,3 +15,4 @@ MonoBehaviour:
   allModels:
   - {fileID: 11400000, guid: a3f4d6ab735ff504596c56b77d84e23c, type: 2}
   - {fileID: 11400000, guid: c8ded03887d54f0488b0aa25162938c0, type: 2}
+  - {fileID: 11400000, guid: df2fb81e530ca4c82a74ba7eb7a7fba8, type: 2}

--- a/Assets/Resources/ScriptableObjects/Models/ZombieCrawler.asset
+++ b/Assets/Resources/ScriptableObjects/Models/ZombieCrawler.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f72d2ead941946040ae7ca8954210991, type: 3}
+  m_Name: ZombieCrawler
+  m_EditorClassIdentifier: 
+  modelName: zombieCrawler
+  prefab: {fileID: 8460791704541548606, guid: 30891c519904b1c48a5db81c103a32a3, type: 3}
+  defaultAnimationSet: {fileID: 11400000, guid: f4787dc5493b2491bbad0b72c6dd2f6d, type: 2}
+  weaponAnimationOverrides: []

--- a/Assets/Resources/ScriptableObjects/Models/ZombieCrawler.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Models/ZombieCrawler.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df2fb81e530ca4c82a74ba7eb7a7fba8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/UnitDatabase.asset
+++ b/Assets/Resources/ScriptableObjects/UnitDatabase.asset
@@ -15,3 +15,4 @@ MonoBehaviour:
   allUnits:
   - {fileID: 11400000, guid: 6fd4da32981caf14591968299cab27c2, type: 2}
   - {fileID: 11400000, guid: f7f015471a4aa9844bf99b8a68aef34a, type: 2}
+  - {fileID: 11400000, guid: ed0a754290980470cab2d19957810449, type: 2}

--- a/Assets/Resources/ScriptableObjects/Units/ZombieCrawler.asset
+++ b/Assets/Resources/ScriptableObjects/Units/ZombieCrawler.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f8c54470ddbb8a4eb4cc39c24fd33d8, type: 3}
+  m_Name: ZombieCrawler
+  m_EditorClassIdentifier: 
+  unitName: zombieCrawler
+  unitType: 1
+  team: 0
+  health: 100
+  maxHealth: 100
+  shield: 0
+  maxShield: 0
+  moveSpeed: 4
+  weapon: {fileID: 11400000, guid: 5a821e469598a924a8ada0962153e09a, type: 2}
+  modelData: {fileID: 11400000, guid: df2fb81e530ca4c82a74ba7eb7a7fba8, type: 2}

--- a/Assets/Resources/ScriptableObjects/Units/ZombieCrawler.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Units/ZombieCrawler.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed0a754290980470cab2d19957810449
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ZombieGameManager.cs
+++ b/Assets/Scripts/ZombieGameManager.cs
@@ -101,7 +101,9 @@ public class ZombieGameManager : NetworkBehaviour
     [Server]
     void SpawnZombie(Vector3 spawnPosition, Quaternion spawnRotation)
     {
-        var zombie = UnitSpawner.Instance.SpawnUnit("zombie", spawnPosition, spawnRotation);
+        var zombieNameToSpawn = UnityEngine.Random.value < 0.8f ? "zombie" : "zombieCrawler";
+
+        var zombie = UnitSpawner.Instance.SpawnUnit(zombieNameToSpawn, spawnPosition, spawnRotation);
         if (zombie == null)
         {
             Debug.LogError("Failed to spawn zombie.");

--- a/Assets/Units/Animations/ZombieCrawlerUnarmed.overrideController
+++ b/Assets/Units/Animations/ZombieCrawlerUnarmed.overrideController
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!221 &22100000
+AnimatorOverrideController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ZombieCrawlerUnarmed
+  m_Controller: {fileID: 9100000, guid: 5d42d8ba6489eee4e82c90ef3d9e7902, type: 2}
+  m_Clips:
+  - m_OriginalClip: {fileID: 7400000, guid: a7e98d51bd73b0348b47acf6a9f02766, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: c6b03fde76676461f8f42377e3979ae6, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: 589a11892e95f834dbf23f9e1cc1f090, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: bbfc190e61bae44988c3198ff7bef998, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: 94c75858633b4e04f9e28db3b52b2bba, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: ac7c93731b2ba425b827f369b9dca37f, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: 67e46c627b0dc094981ffd97753ea72a, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: c6b03fde76676461f8f42377e3979ae6, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: e33349a8bcfb33d45b046fd471f11e59, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: c6b03fde76676461f8f42377e3979ae6, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: a76b11de25f4d4e4ab91d27f3603c7e7, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: c6b03fde76676461f8f42377e3979ae6, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: 34cf87f11bbc57c4b9b73fdd5fa93281, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: c6b03fde76676461f8f42377e3979ae6, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: c3db31be38cd2444c8b58d3cde31e70e, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: c6b03fde76676461f8f42377e3979ae6, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: 3ad1df7d2c4cd6546b760c44f86275e8, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: c6b03fde76676461f8f42377e3979ae6, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: 554523467ee8d4b4ea1722aed5070b8a, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: c6b03fde76676461f8f42377e3979ae6, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: 69f3b1b43eb337548a8633b7b82d6fc6, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: 5ebadad9bb5074a928316744bb08f006, type: 3}
+  - m_OriginalClip: {fileID: 7400000, guid: 3414c515c6a2f334da03b4ab3d547691, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: 5ebadad9bb5074a928316744bb08f006, type: 3}

--- a/Assets/Units/Animations/ZombieCrawlerUnarmed.overrideController.meta
+++ b/Assets/Units/Animations/ZombieCrawlerUnarmed.overrideController.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bfa276def84894d1c9fbec1fce1dcdcc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 22100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Updates the animation settings for the Zombie Crawler, enabling 
looping for smoother animations. Introduces a new unit, 
HumanoidZombieCrawlerUnarmed, and adds it to the model and 
unit databases. Modifies the ZombieGameManager to randomly 
spawn either a standard zombie or the new Zombie Crawler, 
enhancing gameplay variety.