### PR TITLE
fix(weapons): adjust weapon stats for balance and gameplay

### DIFF
--- a/Assets/Resources/ScriptableObjects/Weapons/Daggers.asset
+++ b/Assets/Resources/ScriptableObjects/Weapons/Daggers.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   attackPower: 70
   attackRange: 3
   attackTime: 0.4
-  attackSpeed: 0.2
+  attackSpeed: 0.6
   moveSpeedPercentWhileAttacking: 0.9
   mode: 0
   maxHits: 3

--- a/Assets/Resources/ScriptableObjects/Weapons/Gun.asset
+++ b/Assets/Resources/ScriptableObjects/Weapons/Gun.asset
@@ -16,10 +16,9 @@ MonoBehaviour:
   weaponType: 4
   attackPower: 50
   attackRange: 20
-  attackTime: 0.5
+  attackTime: 0.4
   attackSpeed: 1
   moveSpeedPercentWhileAttacking: 0
-  animationSet: {fileID: 11400000, guid: d4424c69e2fe34c6ebd3e664c1b1733a, type: 2}
   projectileSpeed: 30
   spawnDistance: 1
   projectile: {fileID: 11400000, guid: 7ee758cd32cdca84dabcf4c048db1daf, type: 2}

--- a/Assets/Resources/ScriptableObjects/Weapons/ShortBow.asset
+++ b/Assets/Resources/ScriptableObjects/Weapons/ShortBow.asset
@@ -17,9 +17,8 @@ MonoBehaviour:
   attackPower: 15
   attackRange: 12
   attackTime: 0.4
-  attackSpeed: 0.4
+  attackSpeed: 0.6
   moveSpeedPercentWhileAttacking: 0.5
-  animationSet: {fileID: 11400000, guid: 051281fdff18e4b1abcd3fa9dbb3efe1, type: 2}
   projectileSpeed: 22
   spawnDistance: 1
   projectile: {fileID: 11400000, guid: 7ee758cd32cdca84dabcf4c048db1daf, type: 2}

--- a/Assets/Resources/ScriptableObjects/Weapons/Sword.asset
+++ b/Assets/Resources/ScriptableObjects/Weapons/Sword.asset
@@ -14,13 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   weaponName: sword
   weaponType: 1
-  attackPower: 38
+  attackPower: 25
   attackRange: 3
   attackTime: 0.4
-  attackSpeed: 0.3
+  attackSpeed: 0.8
   moveSpeedPercentWhileAttacking: 0.8
-  animationSet: {fileID: 11400000, guid: a1e66d9cbcbde4be8813018f9d2392fe, type: 2}
   mode: 0
+  maxHits: 5
   coneAngleRadians: 90
   numRays: 20
   weighting: 0.5

--- a/Assets/Units/Animations/ZombieUnarmed.overrideController
+++ b/Assets/Units/Animations/ZombieUnarmed.overrideController
@@ -12,7 +12,7 @@ AnimatorOverrideController:
   - m_OriginalClip: {fileID: 7400000, guid: a7e98d51bd73b0348b47acf6a9f02766, type: 3}
     m_OverrideClip: {fileID: -203655887218126122, guid: fc365aa76b1404f069e87dafa268a74b, type: 3}
   - m_OriginalClip: {fileID: 7400000, guid: 589a11892e95f834dbf23f9e1cc1f090, type: 3}
-    m_OverrideClip: {fileID: -203655887218126122, guid: bbfc190e61bae44988c3198ff7bef998, type: 3}
+    m_OverrideClip: {fileID: -203655887218126122, guid: 779a945dce06e4e1eb91dff2547087b7, type: 3}
   - m_OriginalClip: {fileID: 7400000, guid: 94c75858633b4e04f9e28db3b52b2bba, type: 3}
     m_OverrideClip: {fileID: -203655887218126122, guid: ac7c93731b2ba425b827f369b9dca37f, type: 3}
   - m_OriginalClip: {fileID: 7400000, guid: 67e46c627b0dc094981ffd97753ea72a, type: 3}


### PR DESCRIPTION
Update attack power, attack speed, and attack time for various weapons 
to improve gameplay balance. Adjustments include reducing the sword's 
attack power and increasing its attack speed, while also modifying 
the attack speed for daggers and short bows. The gun's attack time 
is optimized for better performance. Additionally, a new maxHits 
property is added to the sword for enhanced functionality.