### PR TITLE
feat(animation): add dead speed multiplier for unit animations

### DIFF
--- a/Assets/Units/Animations/Unarmed.controller
+++ b/Assets/Units/Animations/Unarmed.controller
@@ -334,6 +334,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
+  - m_Name: DeadSpeedMultiplier
+    m_Type: 1
+    m_DefaultFloat: 1
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -419,16 +425,16 @@ AnimatorState:
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 0
+  m_SpeedParameterActive: 1
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 589a11892e95f834dbf23f9e1cc1f090, type: 3}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: DeadSpeedMultiplier
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
-  m_TimeParameter: 
+  m_TimeParameter: VelocityX
 --- !u!1102 &3195381003125495745
 AnimatorState:
   serializedVersion: 6

--- a/Assets/Units/Animations/UnitAnimationController.cs
+++ b/Assets/Units/Animations/UnitAnimationController.cs
@@ -65,6 +65,10 @@ public class UnitAnimationController : MonoBehaviour
     private void HandleOnHealthChange((int current, int max) health)
     {
         animator.SetInteger("Health", health.current);
+
+        if (health.current <= 0) {
+            animator.SetFloat("DeadSpeedMultiplier", 1f + Random.Range(-0.3f, 0.2f));
+        }
     }
 
     private void HandleOnTakeDamage(UnitController unitController)


### PR DESCRIPTION
Implement a dead speed multiplier in the UnitAnimationController to 
enhance the animation when a unit's health reaches zero. This change 
introduces a random variation to the dead animation speed, improving 
the visual feedback of unit deaths. Update the Unarmed animator 
controller to include the new parameter and ensure it is active 
during the dead state.