### PR TITLE
feat: adjust zombie health scaling with wave progression

### DIFF
--- a/Assets/Scripts/ZombieGameManager.cs
+++ b/Assets/Scripts/ZombieGameManager.cs
@@ -118,6 +118,9 @@ public class ZombieGameManager : NetworkBehaviour
         };
         
         unitController.moveSpeed = Mathf.Max(0, unitController.moveSpeed + UnityEngine.Random.Range(-0.5f, 0.5f));
+        var newMaxHealth = Mathf.Clamp(unitController.maxHealth + (currentWave * 10), 1, 1000);
+        unitController.maxHealth = newMaxHealth;
+        unitController.health = newMaxHealth;
         
         zombie.AddComponent<AiZombieController>();
     }


### PR DESCRIPTION
Update the max health of zombies based on the current wave number. 
Clamp the health value between 1 and 1000 to ensure it remains within 
a reasonable range. This change enhances gameplay by making zombies 
more challenging as players progress through waves.