### PR TITLE
fix: adjust max health scaling for zombie units

### DIFF
--- a/Assets/Scripts/ZombieGameManager.cs
+++ b/Assets/Scripts/ZombieGameManager.cs
@@ -118,7 +118,7 @@ public class ZombieGameManager : NetworkBehaviour
         };
         
         unitController.moveSpeed = Mathf.Max(0, unitController.moveSpeed + UnityEngine.Random.Range(-0.5f, 0.5f));
-        var newMaxHealth = Mathf.Clamp(unitController.maxHealth + (currentWave * 10), 1, 1000);
+        var newMaxHealth = Mathf.Clamp(unitController.maxHealth + ((currentWave - 1) * 5), 1, 1000);
         unitController.maxHealth = newMaxHealth;
         unitController.health = newMaxHealth;
         


### PR DESCRIPTION
Update the max health calculation for zombie units to scale 
based on the current wave. The formula now uses a factor of 
5 instead of 10, ensuring a more gradual increase in health 
as the game progresses. This change aims to improve game 
balance and enhance player experience.