### PR TITLE
refactor(scene): update interaction zones and clean up

### DIFF
--- a/Assets/Prefabs/InteractionZone.prefab
+++ b/Assets/Prefabs/InteractionZone.prefab
@@ -30,7 +30,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 2591162903192323002}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &798276579995439250
@@ -45,7 +46,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cbb424fc7b68a430c8c09bbd9b638567, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  interactionId: 
+  interactionId: 0
   interactionType: 0
   goldCost: 0
 --- !u!135 &6403887692248817249
@@ -69,3 +70,77 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 1.5
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1001 &2591162903192506316
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8928831251772476945}
+    m_Modifications:
+    - target: {fileID: 177120, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_Name
+      value: FX_Ring
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 19953136, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+--- !u!4 &2591162903192323002 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
+  m_PrefabInstance: {fileID: 2591162903192506316}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/ZombyGameScene.unity
+++ b/Assets/Scenes/ZombyGameScene.unity
@@ -4142,9 +4142,13 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 538374348}
     m_Modifications:
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionId
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 8152328801114507560, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
       propertyPath: m_Name
-      value: InteractionZone (1)
+      value: InteractionZone Gate 2
       objectReference: {fileID: 0}
     - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5214,79 +5218,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 410826, guid: faefc7bf0b06adc4497fd8b1694fad68, type: 3}
   m_PrefabInstance: {fileID: 647552950}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &648047269
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2014322979}
-    m_Modifications:
-    - target: {fileID: 177120, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_Name
-      value: FX_Ring
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 3.3317776
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 3.3317776
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 3.3317776
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.13
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.094866864
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.12
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 19953136, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-      propertyPath: m_Materials.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
 --- !u!1001 &661337965
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6883,9 +6814,13 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 538374348}
     m_Modifications:
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionId
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8152328801114507560, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
       propertyPath: m_Name
-      value: InteractionZone
+      value: InteractionZone Gate 1
       objectReference: {fileID: 0}
     - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
       propertyPath: m_LocalPosition.x
@@ -10437,11 +10372,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 410826, guid: faefc7bf0b06adc4497fd8b1694fad68, type: 3}
   m_PrefabInstance: {fileID: 1308117267}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1318353862 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 478326, guid: 8fddca1ea1c00ca4d8f50aa93f290fad, type: 3}
-  m_PrefabInstance: {fileID: 648047269}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1323288287
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10796,9 +10726,13 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 538374348}
     m_Modifications:
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionId
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 8152328801114507560, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
       propertyPath: m_Name
-      value: InteractionZone (2)
+      value: InteractionZone Gate 3
       objectReference: {fileID: 0}
     - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11107,6 +11041,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1522637038}
     m_Modifications:
+    - target: {fileID: 2125118232643204031, guid: a1d84125f8cd19645b3cb6e9acfc2381, type: 3}
+      propertyPath: gateId
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4911740606334818530, guid: a1d84125f8cd19645b3cb6e9acfc2381, type: 3}
       propertyPath: sceneId
       value: 1495783901
@@ -11153,7 +11091,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8601734405583095360, guid: a1d84125f8cd19645b3cb6e9acfc2381, type: 3}
       propertyPath: m_Name
-      value: Gate (1)
+      value: Gate 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -11962,8 +11900,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1782063494}
-  - {fileID: 1401329709}
   - {fileID: 2075233389}
+  - {fileID: 1401329709}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1539243399
@@ -13407,6 +13345,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1522637038}
     m_Modifications:
+    - target: {fileID: 2125118232643204031, guid: a1d84125f8cd19645b3cb6e9acfc2381, type: 3}
+      propertyPath: gateId
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4911740606334818530, guid: a1d84125f8cd19645b3cb6e9acfc2381, type: 3}
       propertyPath: sceneId
       value: 1564110347
@@ -13453,7 +13395,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8601734405583095360, guid: a1d84125f8cd19645b3cb6e9acfc2381, type: 3}
       propertyPath: m_Name
-      value: Gate
+      value: Gate 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -14981,8 +14923,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1318353862}
+  m_Children: []
   m_Father: {fileID: 154434317}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2025059415
@@ -15313,6 +15254,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1522637038}
     m_Modifications:
+    - target: {fileID: 2125118232643204031, guid: a1d84125f8cd19645b3cb6e9acfc2381, type: 3}
+      propertyPath: gateId
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 4911740606334818530, guid: a1d84125f8cd19645b3cb6e9acfc2381, type: 3}
       propertyPath: sceneId
       value: 2143516377
@@ -15359,7 +15304,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8601734405583095360, guid: a1d84125f8cd19645b3cb6e9acfc2381, type: 3}
       propertyPath: m_Name
-      value: Gate (2)
+      value: Gate 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Events/GameEvent.cs
+++ b/Assets/Scripts/Events/GameEvent.cs
@@ -148,4 +148,22 @@ namespace MyGame.Events
             Zone = zone;
         }
     }
+
+    public class OpenGateEvent : GameEvent
+    {
+        public int GateId { get; }
+        public OpenGateEvent(int gateId)
+        {
+            GateId = gateId;
+        }
+    }
+
+    public class CloseGateEvent : GameEvent
+    {
+        public int GateId { get; }
+        public CloseGateEvent(int gateId)
+        {
+            GateId = gateId;
+        }
+    }
 }

--- a/Assets/Scripts/GateController.cs
+++ b/Assets/Scripts/GateController.cs
@@ -1,9 +1,12 @@
 using Mirror;
+using MyGame.Events;
 using UnityEngine;
 using UnityEngine.AI;
 
 public class GateController : NetworkBehaviour
 {
+    public int gateId;
+
     [SerializeField]
     private Collider gateCollider;
 
@@ -32,9 +35,15 @@ public class GateController : NetworkBehaviour
         // Calculate the open position by subtracting the gate's height in the local Y axis
         float height = gateObject.GetComponent<Renderer>().bounds.size.y;
         openPosition = closedPosition - new Vector3(0, height, 0);
-        
+
         // Set the initial state of the gate
         ChangeGateState();
+
+        if (isServer)
+        {
+            EventManager.Instance.Subscribe<OpenGateEvent>(OnOpenGateEvent);
+            EventManager.Instance.Subscribe<CloseGateEvent>(OnCloseGateEvent);
+        }
     }
 
     private void Update()
@@ -101,6 +110,21 @@ public class GateController : NetworkBehaviour
 
         gateObject.transform.position = targetPosition;
         moveCoroutine = null;
+    }
+
+    public void OnOpenGateEvent(OpenGateEvent openGateEvent)
+    {
+        if (openGateEvent.GateId == gateId)
+        {
+            OpenGate();
+        }
+    }
+    public void OnCloseGateEvent(CloseGateEvent closeGateEvent)
+    {
+        if (closeGateEvent.GateId == gateId)
+        {
+            CloseGate();
+        }
     }
 
 #if UNITY_EDITOR

--- a/Assets/Scripts/InteractionZone.cs
+++ b/Assets/Scripts/InteractionZone.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 public class InteractionZone : MonoBehaviour
 {
-    public string interactionId;
+    public int interactionId;
     public InteractionType interactionType;
     public int goldCost = 0;
 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -283,6 +283,7 @@ public class PlayerController : NetworkBehaviour
         {
             case InteractionType.OpenGate:
                 Debug.Log("Open Gate");
+                EventManager.Instance.Publish(new OpenGateEvent(_interactionZone.interactionId));
                 break;
             case InteractionType.BuyWeapon:
                 Debug.Log("Buy Weapon");


### PR DESCRIPTION
Removes unnecessary child objects from the ZombyGameScene and 
updates the names of interaction zones for clarity. Adds 
interaction IDs to the modified prefab instances to enhance 
functionality. This cleanup improves scene organization and 
ensures that interaction zones are clearly identified.