### PR TITLE
refactor(EventManager): remove DontDestroyOnLoad call

### DIFF
--- a/Assets/Scripts/Events/EventManager.cs
+++ b/Assets/Scripts/Events/EventManager.cs
@@ -12,7 +12,6 @@ public class EventManager : MonoBehaviour {
     void Awake() {
         if (Instance == null) {
             Instance = this;
-            DontDestroyOnLoad(gameObject);
         } else {
             Destroy(gameObject);
         }


### PR DESCRIPTION
Remove the DontDestroyOnLoad call in the EventManager's Awake 
method to prevent the event manager from persisting across 
scenes, ensuring a fresh instance is created for each scene.