### PR TITLE
feat(zombie-spawn): enhance zombie spawn logic and properties

### DIFF
--- a/Assets/Scenes/ZombyGameScene.unity
+++ b/Assets/Scenes/ZombyGameScene.unity
@@ -152,6 +152,7 @@ Transform:
   - {fileID: 1942798456}
   - {fileID: 1486329567}
   - {fileID: 1095516604}
+  - {fileID: 1450433403}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2342493
@@ -3003,6 +3004,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1239304}
     m_Modifications:
+    - target: {fileID: 214666152996457870, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: isActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1861838897007135731, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
       propertyPath: m_Name
       value: SpawnZombie
@@ -8491,6 +8496,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1239304}
     m_Modifications:
+    - target: {fileID: 214666152996457870, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: isActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1861838897007135731, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
       propertyPath: m_Name
       value: SpawnZombie (3)
@@ -11422,6 +11431,68 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 467220, guid: e73dff4b52d607f4ca11b85eca8f146b, type: 3}
   m_PrefabInstance: {fileID: 1447253830}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1450433402
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1239304}
+    m_Modifications:
+    - target: {fileID: 1861838897007135731, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_Name
+      value: SpawnZombie (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 25.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+--- !u!4 &1450433403 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+  m_PrefabInstance: {fileID: 1450433402}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1452443643
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11641,6 +11712,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1239304}
     m_Modifications:
+    - target: {fileID: 214666152996457870, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: isActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1861838897007135731, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
       propertyPath: m_Name
       value: SpawnZombie (2)
@@ -14515,6 +14590,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1239304}
     m_Modifications:
+    - target: {fileID: 214666152996457870, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: isActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1861838897007135731, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
       propertyPath: m_Name
       value: SpawnZombie (1)

--- a/Assets/Scripts/ZombieGameManager.cs
+++ b/Assets/Scripts/ZombieGameManager.cs
@@ -94,8 +94,14 @@ public class ZombieGameManager : NetworkBehaviour
 
     Vector3 GetZombieSpawnPosition()
     {
-        int spawnIndex = UnityEngine.Random.Range(0, ZombieSpawns.Length);
-        return ZombieSpawns[spawnIndex].transform.position;
+        var activeSpawns = Array.FindAll(ZombieSpawns, spawn => spawn.isActive);
+        if (activeSpawns.Length == 0)
+        {
+            Debug.LogError("No active zombie spawns available.");
+            return Vector3.zero;
+        }
+        int spawnIndex = UnityEngine.Random.Range(0, activeSpawns.Length);
+        return activeSpawns[spawnIndex].transform.position;
     }
 
     [Server]

--- a/Assets/Scripts/ZombieSpawnController.cs
+++ b/Assets/Scripts/ZombieSpawnController.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class ZombieSpawnController : MonoBehaviour
 {
+    public bool isActive = false;
     // Start is called before the first frame update
     void Start()
     {


### PR DESCRIPTION
Add active state management for zombie spawns to ensure only 
active spawns are considered during selection. Update the 
ZombieSpawnController to include an isActive property. 
Modify the GetZombieSpawnPosition method to handle cases 
where no active spawns are available, improving error handling. 
Update the ZombyGameScene to reflect these changes in prefab 
instances and properties.