### PR TITLE
feat: add ZombieSpawnManager and spawn group logic

### DIFF
--- a/Assets/Scenes/ZombyGameScene.unity
+++ b/Assets/Scenes/ZombyGameScene.unity
@@ -11151,6 +11151,75 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6496390728467142541, guid: a1d84125f8cd19645b3cb6e9acfc2381, type: 3}
   m_PrefabInstance: {fileID: 1401329708}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1407247992
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1407247995}
+  - component: {fileID: 1407247994}
+  - component: {fileID: 1407247993}
+  m_Layer: 0
+  m_Name: ZombieSpawnManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1407247993
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1407247992}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 3349634795
+  _assetId: 0
+  serverOnly: 1
+  visibility: 0
+  hasSpawned: 0
+--- !u!114 &1407247994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1407247992}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e1dee85795ae4d8f8cc452ffc1ffc16, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
+  zombieSpawns: []
+  gateMappings:
+  - gateId: 2
+    spawnGroupId: 0000000001000000
+--- !u!4 &1407247995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1407247992}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1421623764
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11439,6 +11508,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1239304}
     m_Modifications:
+    - target: {fileID: 214666152996457870, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
+      propertyPath: spawnGroupId
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1861838897007135731, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
       propertyPath: m_Name
       value: SpawnZombie (4)
@@ -16220,5 +16293,6 @@ SceneRoots:
   - {fileID: 854878786}
   - {fileID: 2037798482}
   - {fileID: 1645029744}
+  - {fileID: 1407247995}
   - {fileID: 864273879}
   - {fileID: 5953568556793817622}

--- a/Assets/Scripts/ZombieSpawnController.cs
+++ b/Assets/Scripts/ZombieSpawnController.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 public class ZombieSpawnController : MonoBehaviour
 {
     public bool isActive = false;
+    public int spawnGroupId = 0;
+
     // Start is called before the first frame update
     void Start()
     {

--- a/Assets/Scripts/ZombieSpawnManager.cs
+++ b/Assets/Scripts/ZombieSpawnManager.cs
@@ -1,0 +1,56 @@
+using Mirror;
+using MyGame.Events;
+using UnityEngine;
+
+public class ZombieSpawnManager : NetworkBehaviour
+{
+    public ZombieSpawnController[] zombieSpawns;
+    public GateMapping[] gateMappings;
+
+    void Start()
+    {
+        GetAllZombieSpawnInScene();
+
+        if (isServer)
+        {
+            EventManager.Instance.Subscribe<OpenGateEvent>(OnGateOpenEvent);
+        }
+    }
+
+    void OnDestroy()
+    {
+        EventManager.Instance.Unsubscribe<OpenGateEvent>(OnGateOpenEvent);
+    }
+
+    void GetAllZombieSpawnInScene()
+    {
+        zombieSpawns = FindObjectsByType<ZombieSpawnController>(FindObjectsSortMode.None);
+    }
+
+    [System.Serializable]
+    public struct GateMapping
+    {
+        public int gateId;
+        public int[] spawnGroupId;
+    }
+
+    void OnGateOpenEvent(OpenGateEvent openGateEvent)
+    {
+        foreach (var gateMapping in gateMappings)
+        {
+            if (gateMapping.gateId == openGateEvent.GateId)
+            {
+                foreach (var spawnGroupId in gateMapping.spawnGroupId)
+                {
+                    foreach (var zombieSpawn in zombieSpawns)
+                    {
+                        if (zombieSpawn.spawnGroupId == spawnGroupId)
+                        {
+                            zombieSpawn.isActive = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/ZombieSpawnManager.cs.meta
+++ b/Assets/Scripts/ZombieSpawnManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2e1dee85795ae4d8f8cc452ffc1ffc16


### PR DESCRIPTION
Implement the ZombieSpawnManager to manage zombie spawn points in the 
game. Introduce spawn group functionality to activate specific zombie 
spawns based on gate events. Update the scene to include the new 
ZombieSpawnManager GameObject and its associated components. 
Enhance the ZombieSpawnController to support spawn group IDs.