### PR TITLE
feat: manage unit entry and exit in interaction zone

### DIFF
--- a/Assets/Scripts/InteractionZone.cs
+++ b/Assets/Scripts/InteractionZone.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using MyGame.Events;
 using UnityEngine;
 
@@ -7,10 +8,13 @@ public class InteractionZone : MonoBehaviour
     public InteractionType interactionType;
     public int goldCost = 0;
 
+    private HashSet<UnitController> unitsInZone = new HashSet<UnitController>();
+
     private void OnTriggerEnter(Collider other)
     {
         if (other.TryGetComponent<UnitController>(out var unit))
         {
+            unitsInZone.Add(unit);
             EventManager.Instance.Publish(new UnitEnteredInteractionZone(unit, this));
         }
     }
@@ -19,8 +23,18 @@ public class InteractionZone : MonoBehaviour
     {
         if (other.TryGetComponent<UnitController>(out var unit))
         {
+            unitsInZone.Remove(unit);
             EventManager.Instance.Publish(new UnitExitedInteractionZone(unit, this));
         }
+    }
+
+    void OnDisable()
+    {
+        foreach (var unit in unitsInZone)
+        {
+            EventManager.Instance.Publish(new UnitExitedInteractionZone(unit, this));
+        }
+        unitsInZone.Clear();
     }
 
     private void OnDrawGizmos()


### PR DESCRIPTION
Add functionality to track units entering and exiting the interaction zone. 
Implement a HashSet to store units currently in the zone and publish 
events when units enter or exit. Clear the list of units when the 
interaction zone is disabled to ensure proper state management.