### PR TITLE
feat: add weapon purchase system with event handling

### DIFF
--- a/Assets/Scenes/ZombyGameScene.unity
+++ b/Assets/Scenes/ZombyGameScene.unity
@@ -4959,6 +4959,80 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4367079237206763030, guid: a6872c8fb686cbd41a4f1ca1d2ad637e, type: 3}
   m_PrefabInstance: {fileID: 405071399}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &410077450
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 538374348}
+    m_Modifications:
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: goldCost
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionId
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8152328801114507560, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_Name
+      value: InteractionZone Weapon 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+--- !u!4 &410077451 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+  m_PrefabInstance: {fileID: 410077450}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &437279936
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6179,6 +6253,10 @@ Transform:
   - {fileID: 2088171838}
   - {fileID: 184779380}
   - {fileID: 1436518265}
+  - {fileID: 2048738732}
+  - {fileID: 410077451}
+  - {fileID: 1085188561}
+  - {fileID: 1036089775}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &545502577
@@ -11156,6 +11234,80 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 410826, guid: faefc7bf0b06adc4497fd8b1694fad68, type: 3}
   m_PrefabInstance: {fileID: 1023503837}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1036089774
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 538374348}
+    m_Modifications:
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: goldCost
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionId
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8152328801114507560, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_Name
+      value: InteractionZone Weapon 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 35.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -24.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+--- !u!4 &1036089775 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+  m_PrefabInstance: {fileID: 1036089774}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1036620885
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11851,6 +12003,80 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 449136, guid: 1884091fd87919148948d7d0c96d74fe, type: 3}
   m_PrefabInstance: {fileID: 1073843308}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1085188560
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 538374348}
+    m_Modifications:
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: goldCost
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionId
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8152328801114507560, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_Name
+      value: InteractionZone Weapon 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.54
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+--- !u!4 &1085188561 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+  m_PrefabInstance: {fileID: 1085188560}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1091534947
 PrefabInstance:
@@ -14174,6 +14400,80 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 410826, guid: faefc7bf0b06adc4497fd8b1694fad68, type: 3}
   m_PrefabInstance: {fileID: 1277388872}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1287889016
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1287889018}
+  - component: {fileID: 1287889017}
+  - component: {fileID: 1287889019}
+  m_Layer: 0
+  m_Name: BuyWeaponManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1287889017
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1287889016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d5a7495061a14b78ae16f471b770dd4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
+  weaponMappings:
+  - weaponId: 1
+    weaponData: {fileID: 11400000, guid: 923d2dec128b0d348a65e81a8c3ac9fc, type: 2}
+  - weaponId: 2
+    weaponData: {fileID: 11400000, guid: c8313ed289195d541a854ac0e7c818f8, type: 2}
+  - weaponId: 3
+    weaponData: {fileID: 11400000, guid: f287fcc8010e8481898e3987f5ebe009, type: 2}
+  - weaponId: 4
+    weaponData: {fileID: 11400000, guid: b6aba4df57a0e4e4987b7fa1680d0b07, type: 2}
+--- !u!4 &1287889018
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1287889016}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1287889019
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1287889016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 3421598832
+  _assetId: 0
+  serverOnly: 1
+  visibility: 0
+  hasSpawned: 0
 --- !u!1001 &1299067675
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -22878,6 +23178,80 @@ MonoBehaviour:
   myPlayerUnitController: {fileID: 0}
   minFontSize: 2
   maxFontSize: 4
+--- !u!1001 &2048738731
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 538374348}
+    m_Modifications:
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: goldCost
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionId
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 798276579995439250, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: interactionType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8152328801114507560, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_Name
+      value: InteractionZone Weapon 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+--- !u!4 &2048738732 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+  m_PrefabInstance: {fileID: 2048738731}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2056570689
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -24187,5 +24561,6 @@ SceneRoots:
   - {fileID: 1645029744}
   - {fileID: 49581358}
   - {fileID: 1407247995}
+  - {fileID: 1287889018}
   - {fileID: 864273879}
   - {fileID: 5953568556793817622}

--- a/Assets/Scripts/BuyWeaponManager.cs
+++ b/Assets/Scripts/BuyWeaponManager.cs
@@ -1,0 +1,49 @@
+using Mirror;
+using MyGame.Events;
+using UnityEngine;
+
+public class BuyWeaponManager : NetworkBehaviour {
+
+    public static BuyWeaponManager Instance { get; private set; }
+
+    public WeaponMapping[] weaponMappings;
+
+    [System.Serializable]
+    public struct WeaponMapping
+    {
+        public int weaponId;
+        public WeaponData weaponData;
+    }
+
+    private void Awake() {
+        if (Instance != null && Instance != this) {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+    }
+
+    void Start() {
+        if (isServer) {
+            EventManager.Instance.Subscribe<BuyWeaponEvent>(OnWeaponBuyEvent);
+        }
+    }
+    void OnDestroy() {
+        if (isServer) {
+            EventManager.Instance.Subscribe<BuyWeaponEvent>(OnWeaponBuyEvent);
+        }
+    }
+
+    void OnWeaponBuyEvent(BuyWeaponEvent buyWeaponEvent) {
+        Debug.Log($"BuyWeaponEvent: {buyWeaponEvent.WeaponId} {buyWeaponEvent.Buyer.name}");
+        foreach (var weaponMapping in weaponMappings) {
+            if (weaponMapping.weaponId == buyWeaponEvent.WeaponId) {
+                var unitController = buyWeaponEvent.Buyer.Unit.GetComponent<UnitController>();
+                var weaponName = weaponMapping.weaponData.weaponName;
+                unitController.EquipWeapon(weaponName);
+                break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/BuyWeaponManager.cs.meta
+++ b/Assets/Scripts/BuyWeaponManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7d5a7495061a14b78ae16f471b770dd4

--- a/Assets/Scripts/Events/GameEvent.cs
+++ b/Assets/Scripts/Events/GameEvent.cs
@@ -184,4 +184,15 @@ namespace MyGame.Events
             GateId = gateId;
         }
     }
+
+    public class BuyWeaponEvent : GameEvent
+    {
+        public int WeaponId { get; }
+        public PlayerController Buyer { get; }
+        public BuyWeaponEvent(int weaponId, PlayerController buyer)
+        {
+            WeaponId = weaponId;
+            Buyer = buyer;
+        }
+    }
 }

--- a/Assets/Scripts/FloatingInteractTextManager.cs
+++ b/Assets/Scripts/FloatingInteractTextManager.cs
@@ -35,7 +35,21 @@ public class FloatingInteractTextManager : MonoBehaviour
         var hasMyUnitEnteredTheZone = zone.Unit == myPlayerUnitController;
         if (hasMyUnitEnteredTheZone)
         {
-            GameObject textObj = SpawnInteractText($"Press F to interact\n[Cost: {zone.Zone.goldCost} Gold]", zone.Zone.transform);
+            string interactionText;
+            switch (zone.Zone.interactionType)
+            {
+                case InteractionType.OpenGate:
+                    interactionText = "Press F to open the gate";
+                    break;
+                case InteractionType.BuyWeapon:
+                    interactionText = "Press F to buy a weapon";
+                    break;
+                default:
+                    interactionText = "Press F to interact";
+                    break;
+            }
+            interactionText += $"\n[Cost: {zone.Zone.goldCost} Gold]";
+            GameObject textObj = SpawnInteractText(interactionText, zone.Zone.transform);
             activeInteractTexts[zone.Zone.transform] = textObj;
         }
     }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -123,6 +123,7 @@ public class PlayerController : NetworkBehaviour
     [Client]
     void WeaponSwitch()
     {
+        /*
         if (Input.GetKeyDown(KeyCode.E))
         {
             UnitEquipWeapon("sword");
@@ -139,6 +140,7 @@ public class PlayerController : NetworkBehaviour
         {
             UnitEquipWeapon("gun");
         }
+        */
     }
 
     [Client]
@@ -295,6 +297,7 @@ public class PlayerController : NetworkBehaviour
                 break;
             case InteractionType.BuyWeapon:
                 Debug.Log("Buy Weapon");
+                EventManager.Instance.Publish(new BuyWeaponEvent(_interactionZone.interactionId, this));
                 break;
         }
     }


### PR DESCRIPTION
Introduce BuyWeaponManager to handle weapon buying logic on the server.
Add BuyWeaponEvent to signal weapon purchase requests from players.
Update scene with a new weapon interaction zone configured for buying.
This enables players to buy and equip weapons dynamically during gameplay.