### PR TITLE
fix(game): reduce health scaling and update control instructions

### DIFF
--- a/Assets/Scripts/ZombieGameManager.cs
+++ b/Assets/Scripts/ZombieGameManager.cs
@@ -124,7 +124,7 @@ public class ZombieGameManager : NetworkBehaviour
         };
         
         unitController.moveSpeed = Mathf.Max(0, unitController.moveSpeed + UnityEngine.Random.Range(-0.5f, 0.5f));
-        var newMaxHealth = Mathf.Clamp(unitController.maxHealth + ((currentWave - 1) * 5), 1, 1000);
+        var newMaxHealth = Mathf.Clamp(unitController.maxHealth + ((currentWave - 1) * 2), 1, 1000);
         unitController.maxHealth = newMaxHealth;
         unitController.health = newMaxHealth;
         

--- a/Assets/Ui/UiZombieIngame.uxml
+++ b/Assets/Ui/UiZombieIngame.uxml
@@ -10,7 +10,7 @@
             <ui:Label text="Gold: 0" name="labelGold" style="background-color: rgba(0, 0, 0, 0.78); background-image: none; color: rgb(255, 255, 255); -unity-font-style: bold; font-size: 16px; overflow: visible; -unity-text-align: upper-left; text-overflow: clip; white-space: nowrap; flex-wrap: nowrap; display: flex; opacity: 1; margin-top: 0; margin-right: 0; margin-bottom: 20px; margin-left: 0; padding-right: 4px; padding-left: 4px; padding-top: 2px; padding-bottom: 2px; width: auto; border-top-left-radius: 3px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px;" />
         </ui:VisualElement>
         <ui:VisualElement style="flex-grow: 1; border-top-left-radius: 3px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; align-items: flex-end; justify-content: flex-end; align-self: stretch; flex-direction: column; padding-left: 4px;">
-            <ui:Label text="Controls&#10;- Movement: W, A, S, D&#10;- Interact: F&#10;- Bow: Q&#10;- Sword: E&#10;- Daggers: C&#10;- Gun: V" style="-unity-text-align: middle-left; white-space: nowrap; text-overflow: clip; padding-right: 4px; padding-bottom: 20px;" />
+            <ui:Label text="Controls&#10;- Movement: W, A, S, D&#10;- Interact: F&#10;- Attack: L Mouse" style="-unity-text-align: middle-left; white-space: nowrap; text-overflow: clip; padding-right: 4px; padding-bottom: 20px;" />
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>


### PR DESCRIPTION
Decrease zombie max health scaling per wave from 5 to 2 to balance
game difficulty progression. Simplify in-game control UI by replacing
multiple weapon keys with a single "Attack: L Mouse" instruction for
clarity and improved user experience.