### PR TITLE
feat(world ping): add world ping system with network sync

### DIFF
--- a/Assets/Materials/Yellow.mat
+++ b/Assets/Materials/Yellow.mat
@@ -1,0 +1,138 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-3194615371407259110
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Yellow
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _EMISSION
+  - _RECEIVE_SHADOWS_OFF
+  m_InvalidKeywords: []
+  m_LightmapFlags: 2
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2000
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 0
+    - _Smoothness: 0
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.9921568, g: 0.78039217, b: 0, a: 1}
+    - _Color: {r: 0.9921568, g: 0.78039217, b: 0, a: 1}
+    - _EmissionColor: {r: 0.48200467, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.6226415, g: 0.34362763, b: 0.34362763, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Assets/Materials/Yellow.mat.meta
+++ b/Assets/Materials/Yellow.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b389efd0ddee340b3a047bc9754de65d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/WorldPing.prefab
+++ b/Assets/Prefabs/WorldPing.prefab
@@ -1,0 +1,134 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8278489706640874198
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3273799231166036098}
+  - component: {fileID: 5027179221110872729}
+  - component: {fileID: 848076588326030843}
+  m_Layer: 0
+  m_Name: Cylinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3273799231166036098
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8278489706640874198}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.05, z: 0}
+  m_LocalScale: {x: 1.5, y: 0.05, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4053727789209686268}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5027179221110872729
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8278489706640874198}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &848076588326030843
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8278489706640874198}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b389efd0ddee340b3a047bc9754de65d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &9200036481560082642
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4053727789209686268}
+  - component: {fileID: 5512429638292912038}
+  m_Layer: 0
+  m_Name: WorldPing
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4053727789209686268
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9200036481560082642}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3273799231166036098}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5512429638292912038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9200036481560082642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: daf5c95e88e62450d9601b4cc54802c3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Lifetime: 2

--- a/Assets/Prefabs/WorldPing.prefab.meta
+++ b/Assets/Prefabs/WorldPing.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 73a1e5fc900044c99a9b580c045d3d7c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/ModelsScene.unity
+++ b/Assets/Scenes/ModelsScene.unity
@@ -500,7 +500,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 10.22
       objectReference: {fileID: 0}
     - target: {fileID: 8928831251772476945, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
       propertyPath: m_LocalPosition.y
@@ -543,6 +543,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 32c1cf89991974d4eb69b2889b940030, type: 3}
+--- !u!1001 &4027757038546513889
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4053727789209686268, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.47
+      objectReference: {fileID: 0}
+    - target: {fileID: 4053727789209686268, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4053727789209686268, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4053727789209686268, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4053727789209686268, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4053727789209686268, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4053727789209686268, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4053727789209686268, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4053727789209686268, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4053727789209686268, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9200036481560082642, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
+      propertyPath: m_Name
+      value: WorldPing
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
 --- !u!1001 &6369033525076088485
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -667,3 +724,4 @@ SceneRoots:
   - {fileID: 6369033525076088485}
   - {fileID: 1236652869}
   - {fileID: 1877280954697043055}
+  - {fileID: 4027757038546513889}

--- a/Assets/Scenes/ZombyGameScene.unity
+++ b/Assets/Scenes/ZombyGameScene.unity
@@ -8682,6 +8682,51 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 410826, guid: faefc7bf0b06adc4497fd8b1694fad68, type: 3}
   m_PrefabInstance: {fileID: 790828010}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &792921951
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 792921952}
+  - component: {fileID: 792921953}
+  m_Layer: 0
+  m_Name: WorldPingManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &792921952
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 792921951}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &792921953
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 792921951}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d32d1b31b34414e7996b7d3af052eeb8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pingPrefab: {fileID: 9200036481560082642, guid: 73a1e5fc900044c99a9b580c045d3d7c, type: 3}
 --- !u!1001 &793460997
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -24562,5 +24607,6 @@ SceneRoots:
   - {fileID: 49581358}
   - {fileID: 1407247995}
   - {fileID: 1287889018}
+  - {fileID: 792921952}
   - {fileID: 864273879}
   - {fileID: 5953568556793817622}

--- a/Assets/Scripts/Events/GameEvent.cs
+++ b/Assets/Scripts/Events/GameEvent.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using UnityEngine;
+
 namespace MyGame.Events
 {
     /// <summary>
@@ -193,6 +195,16 @@ namespace MyGame.Events
         {
             WeaponId = weaponId;
             Buyer = buyer;
+        }
+    }
+
+    public class WorldPingEvent : GameEvent
+    {
+        public Vector3 Position { get; }
+
+        public WorldPingEvent(Vector3 position)
+        {
+            Position = position;
         }
     }
 }

--- a/Assets/Scripts/WorldPing.cs
+++ b/Assets/Scripts/WorldPing.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+public class WorldPing : MonoBehaviour
+{
+    public float Lifetime = 5f;
+
+    private void Start()
+    {
+        Destroy(gameObject, Lifetime);
+    }
+}

--- a/Assets/Scripts/WorldPing.cs.meta
+++ b/Assets/Scripts/WorldPing.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: daf5c95e88e62450d9601b4cc54802c3

--- a/Assets/Scripts/WorldPingManager.cs
+++ b/Assets/Scripts/WorldPingManager.cs
@@ -1,0 +1,27 @@
+using MyGame.Events;
+using UnityEngine;
+
+public class WorldPingManager : MonoBehaviour
+{
+    public GameObject pingPrefab;
+
+    private void Start()
+    {
+        EventManager.Instance.Subscribe<WorldPingEvent>(OnWorldPingEvent);
+    }
+
+    private void OnDestroy()
+    {
+        EventManager.Instance.Unsubscribe<WorldPingEvent>(OnWorldPingEvent);
+    }
+
+    private void OnWorldPingEvent(WorldPingEvent pingEvent)
+    {
+        SpawnPing(pingEvent.Position);
+    }
+
+    private void SpawnPing(Vector3 position)
+    {
+        Instantiate(pingPrefab, position, Quaternion.identity);
+    }
+}

--- a/Assets/Scripts/WorldPingManager.cs.meta
+++ b/Assets/Scripts/WorldPingManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d32d1b31b34414e7996b7d3af052eeb8

--- a/Assets/Ui/UiZombieIngame.uxml
+++ b/Assets/Ui/UiZombieIngame.uxml
@@ -10,7 +10,7 @@
             <ui:Label text="Gold: 0" name="labelGold" style="background-color: rgba(0, 0, 0, 0.78); background-image: none; color: rgb(255, 255, 255); -unity-font-style: bold; font-size: 16px; overflow: visible; -unity-text-align: upper-left; text-overflow: clip; white-space: nowrap; flex-wrap: nowrap; display: flex; opacity: 1; margin-top: 0; margin-right: 0; margin-bottom: 20px; margin-left: 0; padding-right: 4px; padding-left: 4px; padding-top: 2px; padding-bottom: 2px; width: auto; border-top-left-radius: 3px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px;" />
         </ui:VisualElement>
         <ui:VisualElement style="flex-grow: 1; border-top-left-radius: 3px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; align-items: flex-end; justify-content: flex-end; align-self: stretch; flex-direction: column; padding-left: 4px;">
-            <ui:Label text="Controls&#10;- Movement: W, A, S, D&#10;- Interact: F&#10;- Attack: L Mouse" style="-unity-text-align: middle-left; white-space: nowrap; text-overflow: clip; padding-right: 4px; padding-bottom: 20px;" />
+            <ui:Label text="Controls&#10;- Movement: W, A, S, D&#10;- Interact: F&#10;- Attack: L Mouse&#10;- Ping: Alt + L Mouse" style="-unity-text-align: middle-left; white-space: nowrap; text-overflow: clip; padding-right: 4px; padding-bottom: 20px;" />
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>


### PR DESCRIPTION
Add a world ping feature allowing players to ping locations in the 
game world using Alt + Left Mouse. Implement CmdWorldPing command 
and RpcWorldPing client RPC in PlayerController to synchronize pings 
across server and clients. Introduce WorldPingManager to listen for 
ping events and spawn ping indicators at specified positions. Update 
UI controls label to include ping instructions. Modify input handling 
to prevent firing when Alt is pressed, enabling ping input detection.