### PR TITLE
feat: add grayscale death effect with fade on player death

### DIFF
--- a/Assets/Prefabs/Main Camera.prefab
+++ b/Assets/Prefabs/Main Camera.prefab
@@ -108,7 +108,7 @@ MonoBehaviour:
     m_Bits: 1
   m_VolumeTrigger: {fileID: 0}
   m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
+  m_RenderPostProcessing: 1
   m_Antialiasing: 0
   m_AntialiasingQuality: 2
   m_StopNaN: 0

--- a/Assets/Scenes/ZombyGameScene.unity
+++ b/Assets/Scenes/ZombyGameScene.unity
@@ -21638,6 +21638,71 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 410826, guid: faefc7bf0b06adc4497fd8b1694fad68, type: 3}
   m_PrefabInstance: {fileID: 1909717741}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1911570439
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1911570441}
+  - component: {fileID: 1911570440}
+  - component: {fileID: 1911570442}
+  m_Layer: 0
+  m_Name: GrayEffectVolume
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1911570440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1911570439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IsGlobal: 1
+  priority: 0
+  blendDistance: 0
+  weight: 0
+  sharedProfile: {fileID: 11400000, guid: 88a6b2842698f4884bbe6d718557360b, type: 2}
+--- !u!4 &1911570441
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1911570439}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.4825084, y: 0.7320156, z: 0.42931366}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1911570442
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1911570439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe921ff097c5e44a89cd905a16de776e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MyUnit: {fileID: 0}
+  postProcessVolume: {fileID: 1911570440}
+  fadeDuration: 0.3
 --- !u!1001 &1912645760
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -24591,6 +24656,7 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 146265055}
+  - {fileID: 1911570441}
   - {fileID: 59859921}
   - {fileID: 1548843877}
   - {fileID: 730377713}

--- a/Assets/Scenes/ZombyGameScene/GrayEffectVolume Profile.asset
+++ b/Assets/Scenes/ZombyGameScene/GrayEffectVolume Profile.asset
@@ -1,0 +1,73 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-3854863173662119137
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 66f335fb1ffd8684294ad653bf1c7564, type: 3}
+  m_Name: ColorAdjustments
+  m_EditorClassIdentifier: 
+  active: 1
+  postExposure:
+    m_OverrideState: 0
+    m_Value: 0
+  contrast:
+    m_OverrideState: 0
+    m_Value: 0
+  colorFilter:
+    m_OverrideState: 0
+    m_Value: {r: 1, g: 1, b: 1, a: 1}
+  hueShift:
+    m_OverrideState: 0
+    m_Value: 0
+  saturation:
+    m_OverrideState: 1
+    m_Value: -70
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7fd9488000d3734a9e00ee676215985, type: 3}
+  m_Name: GrayEffectVolume Profile
+  m_EditorClassIdentifier: 
+  components:
+  - {fileID: -3854863173662119137}
+  - {fileID: 9008923906692989657}
+--- !u!114 &9008923906692989657
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 899c54efeace73346a0a16faa3afe726, type: 3}
+  m_Name: Vignette
+  m_EditorClassIdentifier: 
+  active: 1
+  color:
+    m_OverrideState: 1
+    m_Value: {r: 1, g: 0, b: 0, a: 1}
+  center:
+    m_OverrideState: 0
+    m_Value: {x: 0.5, y: 0.5}
+  intensity:
+    m_OverrideState: 1
+    m_Value: 0.364
+  smoothness:
+    m_OverrideState: 1
+    m_Value: 0.093
+  rounded:
+    m_OverrideState: 0
+    m_Value: 0

--- a/Assets/Scenes/ZombyGameScene/GrayEffectVolume Profile.asset.meta
+++ b/Assets/Scenes/ZombyGameScene/GrayEffectVolume Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88a6b2842698f4884bbe6d718557360b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/DeathEffect.cs
+++ b/Assets/Scripts/DeathEffect.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using MyGame.Events;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+public class DeathEffectController : MonoBehaviour
+{
+    public UnitController MyUnit;
+    public Volume postProcessVolume;
+
+    public float fadeDuration = 0.5f;
+
+    private Coroutine _fadeCoroutine;
+
+    void Start()
+    {
+        EventManager.Instance.Subscribe<MyPlayerUnitSpawnedEvent>(OnPlayerUnitSpawned);
+    }
+
+    void OnDestroy()
+    {
+        EventManager.Instance.Unsubscribe<MyPlayerUnitSpawnedEvent>(OnPlayerUnitSpawned);
+    }
+
+    private void OnPlayerUnitSpawned(MyPlayerUnitSpawnedEvent myPlayerUnitSpawnedEvent)
+    {
+        MyUnit = myPlayerUnitSpawnedEvent.PlayerCharacter;
+        MyUnit.OnDied += OnUnitDied;
+        MyUnit.OnRevive += OnUnitRevive;
+    }
+
+    private void OnUnitRevive()
+    {
+        StartFadeCoroutine(false);
+    }
+
+    private void OnUnitDied()
+    {
+        StartFadeCoroutine(true);
+    }
+
+    private void StartFadeCoroutine(bool toGray)
+    {
+        if (_fadeCoroutine != null)
+        {
+            StopCoroutine(_fadeCoroutine);
+        }
+        _fadeCoroutine = StartCoroutine(FadeGrayscale(toGray));
+    }
+
+    IEnumerator FadeGrayscale(bool toGray)
+    {
+        float start = postProcessVolume.weight;
+        float end = toGray ? 1f : 0f;
+        float duration = fadeDuration;
+        float t = 0f;
+
+        while (t < duration)
+        {
+            t += Time.deltaTime;
+            postProcessVolume.weight = Mathf.Lerp(start, end, t / duration);
+            yield return null;
+        }
+
+        postProcessVolume.weight = end;
+        _fadeCoroutine = null;
+    }
+}

--- a/Assets/Scripts/DeathEffect.cs.meta
+++ b/Assets/Scripts/DeathEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fe921ff097c5e44a89cd905a16de776e


### PR DESCRIPTION
Introduce DeathEffectController to fade the screen to grayscale when
the player unit dies and revert on revive. Add a global post-processing
volume for the grayscale effect in the scene. This enhances visual
feedback for player death and revival, improving game feel and clarity.