### PR TITLE
feat(player): add delayed release for Fire1 input command

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -182,18 +182,29 @@ public class PlayerController : NetworkBehaviour
         CmdSetAngle(angle);
     }
 
-
+    private Coroutine _delaySendSetFire1InputCoroutine;
+    
     [Client]
     void InputPressingFire1()
     {
         if (!Input.GetKey(KeyCode.LeftAlt) && !Input.GetKey(KeyCode.RightAlt) && Input.GetButtonDown("Fire1"))
         {
+            if (_delaySendSetFire1InputCoroutine != null)
+            {
+                StopCoroutine(_delaySendSetFire1InputCoroutine);
+            }
             CmdSetFire1(true);
         }
         if (Input.GetButtonUp("Fire1"))
         {
-            CmdSetFire1(false);
+            _delaySendSetFire1InputCoroutine = StartCoroutine(DelaySendSetFire1Input(0.3f, false));
         }
+    }
+
+    private IEnumerator DelaySendSetFire1Input(float delay, bool isPressingFire1)
+    {
+        yield return new WaitForSeconds(delay);
+        CmdSetFire1(isPressingFire1);
     }
 
     [Client]


### PR DESCRIPTION
Introduce a coroutine to delay sending the Fire1 release command by 0.3 
seconds. This prevents rapid toggling of the Fire1 state when the button is 
quickly pressed and released. The coroutine is stopped and restarted if the 
button is pressed again during the delay, ensuring accurate input state is 
sent to the server.