### PR TITLE
fix(game): remove health scaling and reset player gold

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -53,7 +53,7 @@ MonoBehaviour:
   VerticalInput: 0
   Angle: 0
   IsPressingFire1: 0
-  Gold: 10000
+  Gold: 0
 --- !u!114 &8901443433731581867
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ZombieGameManager.cs
+++ b/Assets/Scripts/ZombieGameManager.cs
@@ -124,7 +124,9 @@ public class ZombieGameManager : NetworkBehaviour
         };
         
         unitController.moveSpeed = Mathf.Max(0, unitController.moveSpeed + UnityEngine.Random.Range(-0.5f, 0.5f));
-        var newMaxHealth = Mathf.Clamp(unitController.maxHealth + ((currentWave - 1) * 2), 1, 1000);
+        var newMaxHealth = unitController.maxHealth;
+        // newMaxHealth += Mathf.Clamp(currentWave * 2, 0, 100);
+
         unitController.maxHealth = newMaxHealth;
         unitController.health = newMaxHealth;
         


### PR DESCRIPTION
Remove the scaling of zombie max health based on the current wave to keep
health values consistent and prevent unintended difficulty spikes. Reset
player gold from 10000 to 0 to align with intended game economy
and balance.