### PR TITLE
feat: add stat and buff systems with UnitMediator integration

### DIFF
--- a/Assets/Prefabs/Unit.prefab
+++ b/Assets/Prefabs/Unit.prefab
@@ -468,6 +468,7 @@ GameObject:
   - component: {fileID: 795324802}
   - component: {fileID: -6987186403959014264}
   - component: {fileID: 3010265075052333281}
+  - component: {fileID: 4644873500728417110}
   - component: {fileID: -3108773104642818051}
   - component: {fileID: -135528591289134065}
   - component: {fileID: -8639825436896791559}
@@ -608,6 +609,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3dec34add1ed3104483ec20e6c9975ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &4644873500728417110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 321437018096114333}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f721ce30dd8d416a84a1118aaba06f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
 --- !u!114 &-3108773104642818051
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Buff.cs
+++ b/Assets/Scripts/Buff.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+public abstract class Buff
+{
+    public string BuffId;
+    public float Duration;
+    protected float elapsedTime;
+
+    public List<StatModifier> Modifiers = new();
+    public bool IsPeriodic;
+    public float TickInterval;
+    private float tickTimer;
+
+    public virtual void OnApply(UnitMediator mediator) { }
+    public virtual void OnRemove(UnitMediator mediator) { }
+    public virtual void OnTick(UnitMediator mediator) { }
+
+    public bool Update(float deltaTime, UnitMediator mediator)
+    {
+        elapsedTime += deltaTime;
+
+        if (IsPeriodic)
+        {
+            tickTimer += deltaTime;
+            if (tickTimer >= TickInterval)
+            {
+                tickTimer = 0f;
+                OnTick(mediator);
+            }
+        }
+
+        return elapsedTime >= Duration;
+    }
+}

--- a/Assets/Scripts/Buff.cs.meta
+++ b/Assets/Scripts/Buff.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f4db36c01d654edd841b1ed30af5af1

--- a/Assets/Scripts/BuffHeal.cs
+++ b/Assets/Scripts/BuffHeal.cs
@@ -1,0 +1,19 @@
+public class BuffHeal : Buff
+{
+    public int HealAmount;
+
+    public BuffHeal(float duration, float tickInterval, int healAmount)
+    {
+        BuffId = "BuffHeal";
+        Duration = duration;
+        TickInterval = tickInterval;
+        HealAmount = healAmount;
+        IsPeriodic = true;
+    }
+
+    public override void OnTick(UnitMediator mediator)
+    {
+        base.OnTick(mediator);
+        mediator.UnitController.Heal(HealAmount);
+    }
+}

--- a/Assets/Scripts/BuffHeal.cs.meta
+++ b/Assets/Scripts/BuffHeal.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 00f0a45153a294097953067d491bb755

--- a/Assets/Scripts/BuffSystem.cs
+++ b/Assets/Scripts/BuffSystem.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BuffSystem
+{
+    private UnitMediator mediator;
+    private List<Buff> activeBuffs = new();
+
+    public BuffSystem(UnitMediator mediator)
+    {
+        this.mediator = mediator;
+    }
+
+    public void AddBuff(Buff buff)
+    {
+        activeBuffs.Add(buff);
+        Debug.Log($"Buff {buff.BuffId} added to {mediator.UnitController.name}");
+
+        foreach (var mod in buff.Modifiers)
+            mediator.Stats.ApplyModifier(mod);
+
+        buff.OnApply(mediator);
+    }
+
+    public void RemoveBuff(Buff buff)
+    {
+        if (activeBuffs.Remove(buff))
+        {
+            Debug.Log($"Buff {buff.BuffId} removed from {mediator.UnitController.name}");
+
+            foreach (var mod in buff.Modifiers)
+                mediator.Stats.RemoveModifier(mod);
+
+            buff.OnRemove(mediator);
+        }
+        else
+        {
+            Debug.LogWarning($"Attempted to remove Buff {buff.BuffId}, but it was not found on {mediator.UnitController.name}");
+        }
+    }
+
+    public void Update(float deltaTime)
+    {
+        for (int i = activeBuffs.Count - 1; i >= 0; i--)
+        {
+            var buff = activeBuffs[i];
+            if (mediator.UnitController.IsDead)
+            {
+                RemoveBuff(buff);
+                continue;
+            }
+            bool finished = buff.Update(deltaTime, mediator);
+
+            if (finished)
+            {
+                RemoveBuff(buff);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/BuffSystem.cs.meta
+++ b/Assets/Scripts/BuffSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 42354c178a94e46d086c76d9802b060c

--- a/Assets/Scripts/StatModifier.cs
+++ b/Assets/Scripts/StatModifier.cs
@@ -1,0 +1,20 @@
+public enum StatType
+{
+    Health,
+    MovementSpeed,
+    Shield,
+}
+
+public enum ModifierType
+{
+    Flat,
+    Percent
+}
+
+[System.Serializable]
+public class StatModifier
+{
+    public StatType Type;
+    public float Value;
+    public ModifierType ModifierType;
+}

--- a/Assets/Scripts/StatModifier.cs.meta
+++ b/Assets/Scripts/StatModifier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5d485052c40e042a985099c218f2fe4c

--- a/Assets/Scripts/StatSystem.cs
+++ b/Assets/Scripts/StatSystem.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+public class StatSystem
+{
+    private UnitMediator mediator;
+    public event Action<StatType> OnStatChanged;
+    private Dictionary<StatType, float> baseStats = new();
+    private List<StatModifier> modifiers = new();
+
+    public StatSystem(UnitMediator mediator)
+    {
+        this.mediator = mediator;
+
+        // Example base stats
+        baseStats[StatType.Health] = this.mediator.UnitController.maxHealth;
+        baseStats[StatType.MovementSpeed] = this.mediator.UnitController.moveSpeed;
+        baseStats[StatType.Shield] = this.mediator.UnitController.maxShield;
+    }
+
+    public void ApplyModifier(StatModifier mod)
+    {
+        modifiers.Add(mod);
+        OnStatChanged?.Invoke(mod.Type);
+    }
+
+    public void RemoveModifier(StatModifier mod)
+    {
+        modifiers.Remove(mod);
+        OnStatChanged?.Invoke(mod.Type);
+    }
+
+    public float GetStat(StatType stat)
+    {
+        float value = baseStats.ContainsKey(stat) ? baseStats[stat] : 0;
+
+        foreach (var mod in modifiers)
+        {
+            if (mod.Type != stat) continue;
+
+            if (mod.ModifierType == ModifierType.Flat)
+                value += mod.Value;
+            else if (mod.ModifierType == ModifierType.Percent)
+                value *= 1 + mod.Value;
+        }
+
+        return value;
+    }
+}

--- a/Assets/Scripts/StatSystem.cs.meta
+++ b/Assets/Scripts/StatSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9369cefd2ec7d4009bfb8141a6aefe65

--- a/Assets/Scripts/UnitController.cs
+++ b/Assets/Scripts/UnitController.cs
@@ -106,10 +106,12 @@ public class UnitController : NetworkBehaviour
     public event Action<UnitController> OnTakeDamage = delegate {};
     public event Action OnDied = delegate {};
     public event Action OnRevive = delegate {};
+    private UnitMediator unitMediator;
 
     void Awake()
     {
         weaponController = GetComponent<WeaponController>();
+        unitMediator = GetComponent<UnitMediator>();
     }
     // Start is called before the first frame update
     void Start()
@@ -120,6 +122,21 @@ public class UnitController : NetworkBehaviour
         unitRigidbody = GetComponent<Rigidbody>();
         RaiseHealthChangeEvent();
         RaiseShieldChangeEvent();
+        /*
+        // Example of how to add a buff
+        var buff = new BuffHeal(5, 1f, 5);
+        var modifier = new StatModifier();
+        modifier.ModifierType = ModifierType.Flat;
+        modifier.Type = StatType.Health;
+        modifier.Value = 200;
+        var modifier2 = new StatModifier();
+        modifier2.ModifierType = ModifierType.Percent;
+        modifier2.Type = StatType.MovementSpeed;
+        modifier2.Value = 0.5f;
+        buff.Modifiers.Add(modifier);
+        buff.Modifiers.Add(modifier2);
+        unitMediator.AddBuff(buff);
+        */
     }
 
     void FixedUpdate()

--- a/Assets/Scripts/UnitMediator.cs
+++ b/Assets/Scripts/UnitMediator.cs
@@ -1,0 +1,51 @@
+using System;
+using Mirror;
+using UnityEngine;
+
+public class UnitMediator : NetworkBehaviour
+{
+    public StatSystem Stats { get; private set; }
+    public BuffSystem Buffs { get; private set; }
+    public UnitController UnitController { get; private set; }
+
+    private void Awake()
+    {
+        UnitController = GetComponent<UnitController>();
+        Stats = new StatSystem(this);
+        Buffs = new BuffSystem(this);
+
+        Stats.OnStatChanged += OnStatChanged;
+    }
+
+    private void OnStatChanged(StatType type)
+    {
+        switch (type)
+        {
+            case StatType.Health:
+                UnitController.maxHealth = (int)Stats.GetStat(StatType.Health);
+                break;
+            case StatType.MovementSpeed:
+                UnitController.moveSpeed = Stats.GetStat(StatType.MovementSpeed);
+                break;
+            case StatType.Shield:
+                UnitController.maxShield = (int)Stats.GetStat(StatType.Shield);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, null);
+        }
+    }
+
+    private void Update()
+    {
+        if (!isServer) return;
+
+        Buffs.Update(Time.deltaTime);
+    }
+
+    public void AddBuff(Buff buff)
+    {
+        Debug.Log($"Adding buff {buff.BuffId} to {UnitController.name}");
+        if (!isServer) return;
+        Buffs.AddBuff(buff);
+    }
+}

--- a/Assets/Scripts/UnitMediator.cs.meta
+++ b/Assets/Scripts/UnitMediator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f721ce30dd8d416a84a1118aaba06f1


### PR DESCRIPTION
Introduce StatSystem and BuffSystem to manage unit stats and buffs
separately from UnitController. Add UnitMediator to coordinate these
systems and the UnitController. This enables modular handling of stat
modifiers and timed buffs, improving code organization and flexibility.

Add example buff usage in UnitController to demonstrate how to apply
buffs with flat and percent modifiers. This lays groundwork for future
buff and debuff features affecting unit attributes dynamically.