### PR TITLE
feat(player): improve healing and buff logic on wave start

### DIFF
--- a/Assets/Scripts/Buff.cs
+++ b/Assets/Scripts/Buff.cs
@@ -22,9 +22,9 @@ public abstract class Buff
         if (IsPeriodic)
         {
             tickTimer += deltaTime;
-            if (tickTimer >= TickInterval)
+            while (tickTimer >= TickInterval)
             {
-                tickTimer = 0f;
+                tickTimer -= TickInterval;
                 OnTick(mediator);
             }
         }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using Mirror;
 using Game.Scripts.Controllers;
 using MyGame.Events;
+using System;
 
 public class PlayerController : NetworkBehaviour
 {
@@ -109,8 +110,15 @@ public class PlayerController : NetworkBehaviour
     public void OnWaveStartedHealPlayerUnitFull(WaveStartedEvent waveStartedEvent)
     {
         if (!_unitController) return;
-        _unitController.Heal(_unitController.maxHealth);
+        var healAmount = Mathf.Clamp(_unitController.maxHealth / 2 - _unitController.health, 0, _unitController.maxHealth / 2);
+        _unitController.Heal(healAmount);
         _unitController.Shield(_unitController.maxShield);
+
+        var buffHealAmount = _unitController.maxHealth - _unitController.health;
+        if (buffHealAmount <= 0) return;
+        var buff = new BuffHeal(5, 0.5f, buffHealAmount / 10);
+        _unitController.unitMediator.AddBuff(buff);
+
     }
 
     [Server]

--- a/Assets/Scripts/UnitController.cs
+++ b/Assets/Scripts/UnitController.cs
@@ -106,7 +106,7 @@ public class UnitController : NetworkBehaviour
     public event Action<UnitController> OnTakeDamage = delegate {};
     public event Action OnDied = delegate {};
     public event Action OnRevive = delegate {};
-    private UnitMediator unitMediator;
+    public UnitMediator unitMediator;
 
     void Awake()
     {
@@ -122,21 +122,6 @@ public class UnitController : NetworkBehaviour
         unitRigidbody = GetComponent<Rigidbody>();
         RaiseHealthChangeEvent();
         RaiseShieldChangeEvent();
-        /*
-        // Example of how to add a buff
-        var buff = new BuffHeal(5, 1f, 5);
-        var modifier = new StatModifier();
-        modifier.ModifierType = ModifierType.Flat;
-        modifier.Type = StatType.Health;
-        modifier.Value = 200;
-        var modifier2 = new StatModifier();
-        modifier2.ModifierType = ModifierType.Percent;
-        modifier2.Type = StatType.MovementSpeed;
-        modifier2.Value = 0.5f;
-        buff.Modifiers.Add(modifier);
-        buff.Modifiers.Add(modifier2);
-        unitMediator.AddBuff(buff);
-        */
     }
 
     void FixedUpdate()
@@ -298,6 +283,8 @@ public class UnitController : NetworkBehaviour
     [Server]
     public void Shield(int amount)
     {
+        if (IsDead) return;
+
         // Increase the shield by the shield amount
         shield = Mathf.Min(shield + amount, maxShield);
         RpcOnShield(amount);


### PR DESCRIPTION
Modify OnWaveStartedHealPlayerUnitFull to heal only half the missing
health and fully restore shield, instead of healing to max health.
Add a healing buff that scales with missing health to provide periodic
healing over time. This change balances immediate healing and ongoing
regeneration.

fix(buff): handle multiple buff ticks correctly

Change buff tick logic to use a while loop instead of if statement,
ensuring multiple ticks are processed if enough time has passed. This
prevents missed periodic effects when deltaTime is large.

refactor(unit): expose unitMediator and prevent shield regen if dead

Make unitMediator public for external access. Add a check in Shield()
to prevent shield increase if the unit is dead, avoiding unintended
state changes.

cleanup(unit): remove commented example buff code from Awake()

Delete commented-out example code for adding buffs in UnitController's
Awake method to improve code clarity and maintainability.