### PR TITLE
feat(stats): add SetBaseStat method and unify stat initialization

### DIFF
--- a/Assets/Scripts/StatSystem.cs
+++ b/Assets/Scripts/StatSystem.cs
@@ -18,6 +18,19 @@ public class StatSystem
         baseStats[StatType.Shield] = this.mediator.UnitController.maxShield;
     }
 
+    public void SetBaseStat(StatType stat, float value)
+    {
+        if (baseStats.ContainsKey(stat))
+        {
+            baseStats[stat] = value;
+            OnStatChanged?.Invoke(stat);
+        }
+        else
+        {
+            throw new ArgumentException($"Stat {stat} does not exist.");
+        }
+    }
+
     public void ApplyModifier(StatModifier mod)
     {
         modifiers.Add(mod);

--- a/Assets/Scripts/UnitSpawner.cs
+++ b/Assets/Scripts/UnitSpawner.cs
@@ -34,11 +34,11 @@ public class UnitSpawner : NetworkBehaviour
 
         if (unitController != null)
         {
+            unitController.unitMediator.Stats.SetBaseStat(StatType.Health, unitData.maxHealth);
+            unitController.unitMediator.Stats.SetBaseStat(StatType.MovementSpeed, unitData.moveSpeed);
+            unitController.unitMediator.Stats.SetBaseStat(StatType.Shield, unitData.maxShield);
             unitController.health = unitData.health;
-            unitController.maxHealth = unitData.maxHealth;
             unitController.shield = unitData.shield;
-            unitController.maxShield = unitData.maxShield;
-            unitController.moveSpeed = unitData.moveSpeed;
             unitController.team = unitData.team;
             unitController.unitType = unitData.unitType;
             unitController.unitName = unitData.unitName;

--- a/Assets/Scripts/ZombieGameManager.cs
+++ b/Assets/Scripts/ZombieGameManager.cs
@@ -123,12 +123,14 @@ public class ZombieGameManager : NetworkBehaviour
             NetworkServer.Destroy(zombie);
         };
         
+        /*
         unitController.moveSpeed = Mathf.Max(0, unitController.moveSpeed + UnityEngine.Random.Range(-0.5f, 0.5f));
         var newMaxHealth = unitController.maxHealth;
         // newMaxHealth += Mathf.Clamp(currentWave * 2, 0, 100);
 
         unitController.maxHealth = newMaxHealth;
         unitController.health = newMaxHealth;
+        */
         
         zombie.AddComponent<AiZombieController>();
     }


### PR DESCRIPTION
Commented out random health and speed adjustments in ZombieGameManager to
ensure consistent unit stats. Introduced SetBaseStat in StatSystem to allow
direct base stat updates with validation. Updated UnitSpawner to initialize
unit stats via SetBaseStat, improving stat management consistency and
avoiding direct field assignments.