### PR TITLE
fix(skill): prevent casting skills when unit is dead

### DIFF
--- a/Assets/Scripts/SkillSystem.cs
+++ b/Assets/Scripts/SkillSystem.cs
@@ -87,6 +87,12 @@ public class SkillSystem : NetworkBehaviour
     [Server]
     public void CastSkill(SkillSlotType slot, int index)
     {
+        var isUnitDead = unit.IsDead;
+        if (isUnitDead)
+        {
+            Debug.Log("Unit is dead, cannot cast skill.");
+            return;
+        }
         var list = GetList(slot);
         if (index < 0 || index >= list.Count) return;
         list[index].Cast();


### PR DESCRIPTION
Add a check in CastSkill to stop skill casting if the unit is dead.
This avoids unintended behavior and potential errors by ensuring
skills cannot be cast by dead units. A debug log message is added
to inform when casting is blocked due to unit death.