### PR TITLE
feat(skill system): add ultimate skill and balance skill parameters

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/Dash.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/Dash.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   skillName: Dash
   skillType: 0
   description: 
-  cooldown: 15
+  cooldown: 8
   castCost: 0
   initTrigger: {fileID: 0}
   castTrigger: {fileID: 11400000, guid: adce09b56039448579341867168dde6b, type: 2}

--- a/Assets/Resources/ScriptableObjects/Skills/DashSkillEffectBuffStatSpeed.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/DashSkillEffectBuffStatSpeed.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   StatType: 1
   ModifierType: 1
-  Value: 0.33
-  duration: 10
+  Value: 0.5
+  duration: 3

--- a/Assets/Resources/ScriptableObjects/Skills/HealFor20.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/HealFor20.asset
@@ -12,4 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0b4a9f4bc382e41d899c066ac50ff1b1, type: 3}
   m_Name: HealFor20
   m_EditorClassIdentifier: 
-  healAmount: 2
+  healAmount: 20

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -351,7 +351,7 @@ public class PlayerController : NetworkBehaviour
         }
         if (Input.GetKeyDown(KeyCode.X))
         {
-            CmdUseSkill(SkillSlotType.Ultimate, 1);
+            CmdUseSkill(SkillSlotType.Ultimate, 0);
         }
     }
 

--- a/Assets/Scripts/SkillSystem.cs
+++ b/Assets/Scripts/SkillSystem.cs
@@ -29,6 +29,7 @@ public class SkillSystem : NetworkBehaviour
         AddSkill(SkillSlotType.Normal, "ConeOfCold");
         AddSkill(SkillSlotType.Normal, "IceBlast");
         AddSkill(SkillSlotType.Normal, "Dash");
+        AddSkill(SkillSlotType.Ultimate, "TestSkill");
     }
 
     [Server]


### PR DESCRIPTION
Add a new ultimate skill "TestSkill" to the skill system to expand
player abilities. Correct the heal amount in HealFor20 asset from 2 to
20 to fix an incorrect value. Reduce Dash skill cooldown from 15 to 8
seconds to improve responsiveness. Adjust DashSkillEffectBuffStatSpeed
to increase speed modifier from 0.33 to 0.5 and shorten duration from
10 to 3 seconds for better game balance. Fix ultimate skill input to
use correct skill index (0 instead of 1) in PlayerController.