### PR TITLE
refactor: update skill effect methods to use UnitController

### DIFF
--- a/Assets/Scripts/NetworkedSkillInstance.cs
+++ b/Assets/Scripts/NetworkedSkillInstance.cs
@@ -50,7 +50,7 @@ public class NetworkedSkillInstance : NetworkBehaviour
         if (IsOnCooldown || skillData == null) return;
 
         lastCastTime = NetworkTime.time;
-        skillData.TriggerCast(unit.gameObject);
+        skillData.TriggerCast(unit);
     }
 
     [ContextMenu("Benchmark Cast 100,000x")]
@@ -61,7 +61,7 @@ public class NetworkedSkillInstance : NetworkBehaviour
         var stopwatch = Stopwatch.StartNew();
         for (int i = 0; i < 100000; i++)
         {
-            skillData.TriggerCast(unit.gameObject);
+            skillData.TriggerCast(unit);
         }
         stopwatch.Stop();
         UnityEngine.Debug.Log($"TriggerCast 100.000x: {stopwatch.ElapsedMilliseconds} ms");

--- a/Assets/Scripts/ScriptableObjects/SkillData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillData.cs
@@ -18,14 +18,14 @@ public class SkillData : ScriptableObject
     [Header("UI")]
     public Texture2D iconTexture;
 
-    public void TriggerInit(GameObject caster)
+    public void TriggerInit(UnitController caster)
     {
-        initTrigger?.Execute(caster, new List<GameObject> { caster });
+        initTrigger?.Execute(caster, new List<UnitController> { caster });
     }
 
-    public void TriggerCast(GameObject caster)
+    public void TriggerCast(UnitController caster)
     {
-        castTrigger?.Execute(caster, new List<GameObject> { caster });
+        castTrigger?.Execute(caster, new List<UnitController> { caster });
     }
 }
 

--- a/Assets/Scripts/ScriptableObjects/SkillEffectChainData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectChainData.cs
@@ -7,7 +7,7 @@ public class SkillEffectChainData : ScriptableObject
     [SerializeReference]
     public List<SkillEffectNodeData> rootNodes = new(); 
 
-    public void Execute(GameObject caster, List<GameObject> targets)
+    public void Execute(UnitController caster, List<UnitController> targets)
     {
         foreach (var rootNode in rootNodes)
         {

--- a/Assets/Scripts/ScriptableObjects/SkillEffectConditionLowHealth.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectConditionLowHealth.cs
@@ -6,19 +6,13 @@ public class SkillEffectConditionLowHealthData : SkillEffectData
 {
     public float thresholdPercent = 0.5f;
 
-    public override List<GameObject> Execute(GameObject caster, List<GameObject> targets)
+    public override List<UnitController> Execute(UnitController caster, List<UnitController> targets)
     {
-        List<GameObject> result = new List<GameObject>();
+        List<UnitController> result = new List<UnitController>();
         foreach (var target in targets)
         {
-            var unitController = target.GetComponent<UnitController>();
-            if (unitController == null)
-            {
-                Debug.LogWarning($"Target {target.name} does not have a UnitController component.");
-                continue;
-            }
-            var health = unitController.health;
-            var maxHealth = unitController.maxHealth;
+            var health = target.health;
+            var maxHealth = target.maxHealth;
             float healthPercent = (float)health / (float)maxHealth;
             var isBelowThreshold = healthPercent < thresholdPercent;
             if (isBelowThreshold)

--- a/Assets/Scripts/ScriptableObjects/SkillEffectData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectData.cs
@@ -3,5 +3,5 @@ using UnityEngine;
 
 public abstract class SkillEffectData : ScriptableObject
 {
-    public abstract List<GameObject> Execute(GameObject caster, List<GameObject> targets);
+    public abstract List<UnitController> Execute(UnitController caster, List<UnitController> targets);
 }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicBuffStatData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicBuffStatData.cs
@@ -9,17 +9,11 @@ public class SkillEffectMechanicBuffStatData : SkillEffectData
     public ModifierType ModifierType;
     public float Value;
     public float duration = 5f;
-    public override List<GameObject> Execute(GameObject caster, List<GameObject> targets)
+    public override List<UnitController> Execute(UnitController caster, List<UnitController> targets)
     {
         foreach (var target in targets)
         {
-            var unitController = target.GetComponent<UnitController>();
-            if (unitController == null)
-            {
-                Debug.LogWarning($"Target {target.name} does not have a UnitController component.");
-                continue;
-            }
-            UnitMediator mediator = unitController.unitMediator;
+            UnitMediator mediator = target.unitMediator;
             if (mediator == null)
             {
                 Debug.LogWarning($"Target {target.name} does not have a UnitMediator component.");

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicDamageData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicDamageData.cs
@@ -7,19 +7,12 @@ public class SkillEffectMechanicDamageData : SkillEffectData
     public int amount = 20;
 
     
-    public override List<GameObject> Execute(GameObject caster, List<GameObject> targets)
+    public override List<UnitController> Execute(UnitController caster, List<UnitController> targets)
     {
-        var casterUnit = caster.GetComponent<UnitController>();
         Debug.Log($"Executing Damage Effect on {targets.Count} targets.");
         foreach (var target in targets)
         {
-            var unitController = target.GetComponent<UnitController>();
-            if (unitController == null)
-            {
-                Debug.LogWarning($"Target {target.name} does not have a UnitController component.");
-                continue;
-            }
-            unitController.TakeDamage(amount, casterUnit);
+            target.TakeDamage(amount, caster);
             Debug.Log($"Damaged {target.name} for {amount} health.");
         }
         return targets;

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicHealEffect.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicHealEffect.cs
@@ -6,18 +6,12 @@ public class SkillEffectMechanicHeal : SkillEffectData
 {
     public int healAmount = 20;
 
-    public override List<GameObject> Execute(GameObject caster, List<GameObject> targets)
+    public override List<UnitController> Execute(UnitController caster, List<UnitController> targets)
     {
         Debug.Log($"Executing Heal Effect on {targets.Count} targets.");
         foreach (var target in targets)
         {
-            var unitController = target.GetComponent<UnitController>();
-            if (unitController == null)
-            {
-                Debug.LogWarning($"Target {target.name} does not have a UnitController component.");
-                continue;
-            }
-            unitController.Heal(healAmount);
+            target.Heal(healAmount);
             Debug.Log($"Healed {target.name} for {healAmount} health.");
         }
         return targets;

--- a/Assets/Scripts/ScriptableObjects/SkillEffectNearbyEnemiesData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectNearbyEnemiesData.cs
@@ -6,15 +6,21 @@ public class SkillEffektNearbyEnemiesData : SkillEffectData
 {
     public float range = 5f;
 
-    public override List<GameObject> Execute(GameObject caster, List<GameObject> targets)
+    public override List<UnitController> Execute(UnitController caster, List<UnitController> targets)
     {
-        List<GameObject> result = new List<GameObject>();
+        List<UnitController> result = new List<UnitController>();
         Collider[] hits = Physics.OverlapSphere(caster.transform.position, range);
         foreach (var hit in hits)
         {
             if (hit.gameObject.CompareTag("Enemy"))
             {
-                result.Add(hit.gameObject);
+                var unitController = hit.GetComponent<UnitController>();
+                if (unitController == null)
+                {
+                    Debug.LogWarning($"Hit object {hit.name} does not have a UnitController component.");
+                    continue;
+                }
+                result.Add(unitController);
             }
         }
         return result;

--- a/Assets/Scripts/ScriptableObjects/SkillEffectNodeData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectNodeData.cs
@@ -11,11 +11,11 @@ public class SkillEffectNodeData
     [SerializeReference]
     public List<SkillEffectNodeData> children = new List<SkillEffectNodeData>();
 
-    public void Execute(GameObject caster, List<GameObject> targets)
+    public void Execute(UnitController caster, List<UnitController> targets)
     {
         if (effect == null) return;
 
-        List<GameObject> nextTargets = effect.Execute(caster, targets);
+        List<UnitController> nextTargets = effect.Execute(caster, targets);
         foreach (var child in children)
         {
             child.Execute(caster, nextTargets);

--- a/Assets/Scripts/ScriptableObjects/SkillEffectTargetConeData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectTargetConeData.cs
@@ -8,16 +8,12 @@ public class SkillEffectTargetCone : SkillEffectData
     public float angle = 45f;
     public LayerMask unitLayer;
 
-    public override List<GameObject> Execute(GameObject caster, List<GameObject> targets)
+    public override List<UnitController> Execute(UnitController caster, List<UnitController> targets)
     {
-        List<GameObject> result = new List<GameObject>();
+        List<UnitController> result = new List<UnitController>();
 
-        if (caster == null) return result;
 
-        var casterUnit = caster.GetComponent<UnitController>();
-        if (casterUnit == null) return result;
-
-        int casterTeam = casterUnit.team;
+        int casterTeam = caster.team;
         Vector3 casterPosition = caster.transform.position;
         Vector3 forward = caster.transform.forward;
 
@@ -40,7 +36,7 @@ public class SkillEffectTargetCone : SkillEffectData
             float angleToTarget = Vector3.Angle(forward, directionToTarget);
             if (angleToTarget <= angle * 0.5f)
             {
-                result.Add(unit.gameObject);
+                result.Add(unit);
             }
         }
 
@@ -48,7 +44,7 @@ public class SkillEffectTargetCone : SkillEffectData
         SkillEffectTargetConeDebugDrawer drawer = caster.GetComponent<SkillEffectTargetConeDebugDrawer>();
         if (drawer == null)
         {
-            drawer = caster.AddComponent<SkillEffectTargetConeDebugDrawer>();
+            drawer = caster.gameObject.AddComponent<SkillEffectTargetConeDebugDrawer>();
         }
 
         drawer.origin = casterPosition;

--- a/Assets/Scripts/ScriptableObjects/SkillEffectTargetLinearData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectTargetLinearData.cs
@@ -9,14 +9,10 @@ public class SkillEffectTargetLinear : SkillEffectData
     public LayerMask unitLayer;
 
 
-    public override List<GameObject> Execute(GameObject caster, List<GameObject> targets)
+    public override List<UnitController> Execute(UnitController caster, List<UnitController> targets)
     {
-        List<GameObject> result = new List<GameObject>();
+        List<UnitController> result = new List<UnitController>();
 
-        if (caster == null) return result;
-
-        UnitController casterController = caster.GetComponent<UnitController>();
-        if (casterController == null) return result;
 
         Vector3 origin = caster.transform.position + Vector3.up;
         Vector3 direction = caster.transform.forward;
@@ -28,13 +24,13 @@ public class SkillEffectTargetLinear : SkillEffectData
             UnitController targetController = hit.collider.GetComponentInParent<UnitController>();
 
             if (targetController != null &&
-                targetController != casterController &&
+                targetController != caster &&
                 !targetController.IsDead &&
-                targetController.team != casterController.team)
+                targetController.team != caster.team)
             {
-                if (!result.Contains(targetController.gameObject))
+                if (!result.Contains(targetController))
                 {
-                    result.Add(targetController.gameObject);
+                    result.Add(targetController);
                 }
             }
         }
@@ -43,7 +39,7 @@ public class SkillEffectTargetLinear : SkillEffectData
         SkillEffectTargetLinearDebugDrawer drawer = caster.GetComponent<SkillEffectTargetLinearDebugDrawer>();
         if (drawer == null)
         {
-            drawer = caster.AddComponent<SkillEffectTargetLinearDebugDrawer>();
+            drawer = caster.gameObject.AddComponent<SkillEffectTargetLinearDebugDrawer>();
         }
 
         drawer.origin = origin;


### PR DESCRIPTION
Change Execute methods in skill effect classes to accept and return
UnitController instances instead of GameObjects. This improves type
safety and simplifies access to unit-specific properties like team and
health. Update related calls and checks accordingly to ensure consistent
usage of UnitController throughout skill effect logic.