### PR TITLE
feat(buff): add flexible uniqueness modes for buffs

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/SwiftnessSkillEffectBuffStatSpeed.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/SwiftnessSkillEffectBuffStatSpeed.asset
@@ -17,4 +17,4 @@ MonoBehaviour:
   ModifierType: 1
   Value: 0.5
   duration: 3
-  isUnique: 1
+  uniqueMode: 1

--- a/Assets/Scripts/Buff.cs
+++ b/Assets/Scripts/Buff.cs
@@ -4,18 +4,24 @@ public abstract class Buff
 {
     public string BuffId { get; }
     public float Duration { get; }
-    public bool IsUnique { get; }
+    public UniqueMode UniqueMode { get; }
+    public UnitMediator Caster { get; }
 
     private float _elapsed;
 
-    protected Buff(string buffId, float duration, bool isUnique = false)
+    protected Buff(string buffId, float duration, UniqueMode uniqueMode = UniqueMode.None,
+        UnitMediator caster = null)
     {
         if (string.IsNullOrWhiteSpace(buffId))
             throw new ArgumentException("Buff must have a non-empty Id.", nameof(buffId));
 
+        if (uniqueMode == UniqueMode.PerCaster && caster == null)
+            throw new ArgumentException("PerCaster buffs need a non-null caster", nameof(caster));
+
         BuffId = buffId;
         Duration = duration;
-        IsUnique = isUnique;
+        UniqueMode = uniqueMode;
+        Caster     = caster;
     }
 
     public virtual void OnApply(UnitMediator mediator) { }
@@ -25,8 +31,15 @@ public abstract class Buff
     public virtual bool Update(float deltaTime, UnitMediator mediator)
     {
         _elapsed += deltaTime;
-        if (_elapsed >= Duration)
-            return true;
-        return false;
+
+        var hasDurationElapsed = _elapsed >= Duration;
+        return hasDurationElapsed;
     }
+}
+
+public enum UniqueMode
+{
+    None,
+    Global,     // only one buff.Id on the target
+    PerCaster   // only one buff.Id *from the same Caster* on the target
 }

--- a/Assets/Scripts/BuffHealOverTime.cs
+++ b/Assets/Scripts/BuffHealOverTime.cs
@@ -4,21 +4,26 @@ public class BuffHealOverTime : PeriodicBuff
 {
     private readonly float _healAmount;
     private readonly ModifierType _modifierType = ModifierType.Flat;
+    private float _residual;
 
     public BuffHealOverTime(
         string buffId,
         float duration,
-        bool isUnique,
         float tickInterval,
-        float healAmount
+        float healAmount,
+        ModifierType   modifierType  = ModifierType.Flat,
+        UniqueMode     uniqueMode    = UniqueMode.None,
+        UnitMediator   caster        = null
     ) : base(
         buffId,
         duration,
         tickInterval,
-        isUnique
+        uniqueMode,
+        caster
       )
     {
         _healAmount = healAmount;
+        _modifierType   = modifierType;
     }
 
     public override void OnApply(UnitMediator mediator)
@@ -29,11 +34,10 @@ public class BuffHealOverTime : PeriodicBuff
 
     public override void OnRemove(UnitMediator mediator)
     {
-        base.OnApply(mediator);
+        base.OnRemove(mediator);
         // cleanup VFX, if any
     }
 
-    private float _residual;
 
     public override void OnTick(UnitMediator mediator)
     {

--- a/Assets/Scripts/BuffPeriodic.cs
+++ b/Assets/Scripts/BuffPeriodic.cs
@@ -8,8 +8,9 @@ public abstract class PeriodicBuff : Buff
         string buffId,
         float duration,
         float tickInterval,
-        bool isUnique = false
-    ) : base(buffId, duration, isUnique)
+        UniqueMode     uniqueMode   = UniqueMode.None,
+        UnitMediator   caster       = null
+    ) : base(buffId, duration, uniqueMode, caster)
     {
         if (tickInterval <= 0f)
             throw new ArgumentException("Tick interval must be > 0.", nameof(tickInterval));

--- a/Assets/Scripts/BuffStat.cs
+++ b/Assets/Scripts/BuffStat.cs
@@ -4,8 +4,13 @@ public class BuffStat : Buff
 {
     private readonly List<StatModifier> _mods;
 
-    public BuffStat(string buffId, float duration, bool isUnique, List<StatModifier> mods)
-        : base(buffId, duration, isUnique)
+    public BuffStat(
+        string buffId,
+        float duration,
+        List<StatModifier> mods,
+        UniqueMode           uniqueMode = UniqueMode.None,
+        UnitMediator         caster     = null)
+        : base(buffId, duration, uniqueMode, caster)
     {
         _mods = mods;
     }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicBuffStatData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicBuffStatData.cs
@@ -9,7 +9,7 @@ public class SkillEffectMechanicBuffStatData : SkillEffectMechanic
     public ModifierType ModifierType;
     public float Value;
     public float duration = 5f;
-    public bool isUnique = true;
+    public UniqueMode uniqueMode = UniqueMode.None;
 
     public override List<UnitController> DoMechanic(UnitController caster, List<UnitController> targets)
     {
@@ -31,7 +31,7 @@ public class SkillEffectMechanicBuffStatData : SkillEffectMechanic
                 }
             };
 
-            BuffStat buff = new BuffStat(buffId, duration, isUnique, listStatModifiers);
+            BuffStat buff = new BuffStat(buffId, duration, listStatModifiers, uniqueMode, caster.unitMediator);
             mediator.AddBuff(buff);
             Debug.Log($"Applied BuffStat to {target.name}: {StatType}, {ModifierType}, {Value}");
         }


### PR DESCRIPTION
Introduce UniqueMode enum to support global and per-caster uniqueness
for buffs, replacing the previous simple IsUnique flag. Update BuffSystem
to handle these modes by removing existing buffs accordingly before adding
new ones. Modify Buff constructor and related skill effect data to use the
new uniqueness system. This enables more precise control over buff stacking
and replacement behavior.