### PR TITLE
feat(skill): add HealingLeaf skill with heal-over-time effect

### DIFF
--- a/Assets/Resources/ScriptableObjects/SkillDatabase.asset
+++ b/Assets/Resources/ScriptableObjects/SkillDatabase.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 27ee134f350b64d6e8f31f683005c87f, type: 2}
   - {fileID: 11400000, guid: ac6078070c7ec4b2384ae5fece1a8228, type: 2}
   - {fileID: 11400000, guid: 72605801f490942fab2d38cec8c6dd48, type: 2}
+  - {fileID: 11400000, guid: e5db02784e0f54432a5ea2e7f61f5850, type: 2}

--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf.meta
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 37b13e3f8bf9e43539dc4c6b950c5149
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeaf.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeaf.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 378dd7e5080dd4bddbceb7b8fe17676d, type: 3}
+  m_Name: HealingLeaf
+  m_EditorClassIdentifier: 
+  skillName: HealingLeaf
+  skillType: 0
+  description: 
+  cooldown: 3
+  castCost: 0
+  initTrigger: {fileID: 0}
+  castTrigger: {fileID: 11400000, guid: f1709d739b738412eab25f42b4d50ab6, type: 2}
+  iconTexture: {fileID: 2800000, guid: bfb9910e2b4ec4e16859c5854f07dac0, type: 3}

--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeaf.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeaf.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5db02784e0f54432a5ea2e7f61f5850
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafHealOverTime.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafHealOverTime.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60d0f817aaa974e4bbc469575ccee556, type: 3}
+  m_Name: HealingLeafHealOverTime
+  m_EditorClassIdentifier: 
+  buffId: HealingLeaf
+  modifierType: 0
+  healAmount: 15
+  duration: 9
+  tickInterval: 3
+  uniqueMode: 2

--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafHealOverTime.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafHealOverTime.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7bb4abf1ed455415e8221cfe7ba3c344
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafSkillEffectChain.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafSkillEffectChain.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4419ac8082e684e89b2b3a9996b66935, type: 3}
+  m_Name: HealingLeafSkillEffectChain
+  m_EditorClassIdentifier: 
+  rootNodes:
+  - rid: 6751759145628336213
+  references:
+    version: 2
+    RefIds:
+    - rid: 6751759145628336213
+      type: {class: SkillEffectNodeData, ns: , asm: Assembly-CSharp}
+      data:
+        effect: {fileID: 11400000, guid: 7bb4abf1ed455415e8221cfe7ba3c344, type: 2}
+        children: []

--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafSkillEffectChain.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafSkillEffectChain.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1709d739b738412eab25f42b4d50ab6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicHealOverTime.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicHealOverTime.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Game/Skills/Effects/Mechanic/HealOverTime")]
+public class SkillEffectMechanicHealOverTime : SkillEffectMechanic
+{
+    public string buffId;
+    public ModifierType modifierType;
+    public int healAmount;
+    public float duration;
+    public  float tickInterval;
+    public UniqueMode uniqueMode = UniqueMode.None;
+
+    public override List<UnitController> DoMechanic(UnitController caster, List<UnitController> targets)
+    {
+        Debug.Log($"Executing Heal Over Time Effect on {targets.Count} targets.");
+        foreach (var target in targets)
+        {
+            UnitMediator mediator = target.unitMediator;
+            if (mediator == null)
+            {
+                Debug.LogWarning($"Target {target.name} does not have a UnitMediator component.");
+                continue;
+            }
+
+            BuffHealOverTime buff = new BuffHealOverTime(
+                buffId,
+                duration,
+                tickInterval,
+                healAmount,
+                modifierType,
+                uniqueMode,
+                caster.unitMediator
+            );
+
+            mediator.AddBuff(buff);
+            Debug.Log($"Applied Heal Over Time to {target.name}: {healAmount} every {tickInterval} seconds.");
+        }
+        return targets;
+    }
+}

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicHealOverTime.cs.meta
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicHealOverTime.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 60d0f817aaa974e4bbc469575ccee556

--- a/Assets/Scripts/SkillSystem.cs
+++ b/Assets/Scripts/SkillSystem.cs
@@ -29,7 +29,7 @@ public class SkillSystem : NetworkBehaviour
         AddSkill(SkillSlotType.Normal, "ConeOfCold");
         AddSkill(SkillSlotType.Normal, "IceBlast");
         AddSkill(SkillSlotType.Normal, "Swiftness");
-        AddSkill(SkillSlotType.Ultimate, "TestSkill");
+        AddSkill(SkillSlotType.Ultimate, "HealingLeaf");
     }
 
     [Server]

--- a/Assets/Ui/UI Toolkit/PanelSettings.asset
+++ b/Assets/Ui/UI Toolkit/PanelSettings.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   m_ReferenceSpritePixelsPerUnit: 100
   m_PixelsPerUnit: 100
   m_Scale: 1
-  m_ReferenceDpi: 96
+  m_ReferenceDpi: 182
   m_FallbackDpi: 96
   m_ReferenceResolution: {x: 1200, y: 800}
   m_ScreenMatchMode: 0


### PR DESCRIPTION
Introduce a new HealingLeaf skill including its skill effect chain and 
heal-over-time mechanic. Register HealingLeaf as an ultimate skill in 
the SkillSystem to enable its use. Adjust UI panel DPI for better display 
scaling. These changes add a new healing ability to enhance gameplay and 
provide players with more strategic options.