### PR TITLE
feat(skill system): add skill removal and update HealingLeaf skill

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeaf.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeaf.asset
@@ -17,6 +17,6 @@ MonoBehaviour:
   description: 
   cooldown: 3
   castCost: 0
-  initTrigger: {fileID: 0}
+  initTrigger: {fileID: 11400000, guid: f1709d739b738412eab25f42b4d50ab6, type: 2}
   castTrigger: {fileID: 11400000, guid: f1709d739b738412eab25f42b4d50ab6, type: 2}
   iconTexture: {fileID: 2800000, guid: bfb9910e2b4ec4e16859c5854f07dac0, type: 3}

--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafHealOverTime.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafHealOverTime.asset
@@ -15,6 +15,6 @@ MonoBehaviour:
   buffId: HealingLeaf
   modifierType: 0
   healAmount: 15
-  duration: 9
+  duration: Infinity
   tickInterval: 3
   uniqueMode: 2

--- a/Assets/Scripts/SkillSystem.cs
+++ b/Assets/Scripts/SkillSystem.cs
@@ -43,6 +43,7 @@ public class SkillSystem : NetworkBehaviour
         AddSkill(SkillSlotType.Normal, "IceBlast");
         AddSkill(SkillSlotType.Normal, "Swiftness");
         AddSkill(SkillSlotType.Ultimate, "HealingLeaf");
+        RemoveSkill(SkillSlotType.Ultimate, 0);
     }
 
     [Server]
@@ -80,6 +81,21 @@ public class SkillSystem : NetworkBehaviour
         }
 
         netSkill.skillData.TriggerInit(unit);
+    }
+
+    [Server]
+    public void RemoveSkill(SkillSlotType slotType, int index)
+    {
+        var list = GetList(slotType);
+        if (index < 0 || index >= list.Count) return;
+
+        var skillToRemove = list[index];
+        list.RemoveAt(index);
+
+        if (skillToRemove != null && skillToRemove.gameObject != null)
+        {
+            NetworkServer.Destroy(skillToRemove.gameObject);
+        }
     }
 
     private SyncList<NetworkedSkillInstance> GetList(SkillSlotType type)


### PR DESCRIPTION
Set HealingLeaf's initTrigger to properly initialize the skill on cast.
Change HealingLeafHealOverTime duration to infinite for continuous healing.
Add RemoveSkill method to SkillSystem to allow removing skills at runtime.
Remove the default HealingLeaf ultimate skill after adding it to prevent duplication.