### PR TITLE
fix(skill system): improve skill initialization and logging on removal

### DIFF
--- a/Assets/Scripts/RotateObject.cs
+++ b/Assets/Scripts/RotateObject.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using Mirror;
 

--- a/Assets/Scripts/SkillSystem.cs
+++ b/Assets/Scripts/SkillSystem.cs
@@ -39,11 +39,12 @@ public class SkillSystem : NetworkBehaviour
     [Server]
     private void InitializeSlots()
     {
+        //AddSkill(SkillSlotType.Passive, "HealingLeaf");
         AddSkill(SkillSlotType.Normal, "ConeOfCold");
         AddSkill(SkillSlotType.Normal, "IceBlast");
         AddSkill(SkillSlotType.Normal, "Swiftness");
         AddSkill(SkillSlotType.Ultimate, "HealingLeaf");
-        RemoveSkill(SkillSlotType.Ultimate, 0);
+        //RemoveSkill(SkillSlotType.Passive, 0);
     }
 
     [Server]
@@ -96,6 +97,8 @@ public class SkillSystem : NetworkBehaviour
         {
             NetworkServer.Destroy(skillToRemove.gameObject);
         }
+        Debug.Log($"Removed skill {skillToRemove.skillName} from {unit.name}");
+        Debug.Log($"{ultimateSkills.Count} ultimate skills found.");
     }
 
     private SyncList<NetworkedSkillInstance> GetList(SkillSlotType type)
@@ -133,7 +136,15 @@ public class SkillSystem : NetworkBehaviour
     [Server]
     public void OnUnitRevive()
     {
-        foreach (var skill in passiveSkills.Concat(normalSkills).Concat(ultimateSkills))
+        foreach (var skill in passiveSkills)
+        {
+            skill.skillData.TriggerInit(unit);
+        }
+        foreach (var skill in normalSkills)
+        {
+            skill.skillData.TriggerInit(unit);
+        }
+        foreach (var skill in ultimateSkills)
         {
             skill.skillData.TriggerInit(unit);
         }

--- a/Assets/Scripts/UnitController.cs
+++ b/Assets/Scripts/UnitController.cs
@@ -221,6 +221,7 @@ public class UnitController : NetworkBehaviour
         if (health <= 0)
         {
             OnKillEvent(attacker);
+            Die();
         }
     }
 
@@ -312,11 +313,11 @@ public class UnitController : NetworkBehaviour
 
     void HookOnHealthChanged(int oldValue, int newValue)
     {
-        if (oldValue > 0 && newValue <= 0)
+        if (!isServer && oldValue > 0 && newValue <= 0)
         {
             Die();
         }
-        if(oldValue == 0 && newValue > 0)
+        if(!isServer && oldValue == 0 && newValue > 0)
         {
             Revive();
         }


### PR DESCRIPTION
Refactor skill initialization in OnUnitRevive to trigger each skill type
separately for clearer execution flow. Add debug logs when removing skills
to aid in tracking skill removals during runtime. Fix health change hooks
to call Die and Revive only on clients, preventing server-side duplicate
calls. Ensure Die is called on death in UnitController to trigger proper
cleanup. Remove unused usings in RotateObject.cs for cleaner code.