### PR TITLE
fix: limit HealingLeaf heal over time duration

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeaf.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeaf.asset
@@ -17,6 +17,6 @@ MonoBehaviour:
   description: 
   cooldown: 3
   castCost: 0
-  initTrigger: {fileID: 11400000, guid: f1709d739b738412eab25f42b4d50ab6, type: 2}
+  initTrigger: {fileID: 0}
   castTrigger: {fileID: 11400000, guid: f1709d739b738412eab25f42b4d50ab6, type: 2}
   iconTexture: {fileID: 2800000, guid: bfb9910e2b4ec4e16859c5854f07dac0, type: 3}

--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafHealOverTime.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeafHealOverTime.asset
@@ -15,6 +15,6 @@ MonoBehaviour:
   buffId: HealingLeaf
   modifierType: 0
   healAmount: 15
-  duration: Infinity
+  duration: 9
   tickInterval: 3
   uniqueMode: 2


### PR DESCRIPTION
Set the HealingLeaf heal over time effect duration from infinite to 9
seconds to prevent unintended permanent healing. Also reset the initTrigger
reference to null to fix potential initialization issues with the skill.