### PR TITLE
refactor(skill): unify skill effect execution with CastContext

### DIFF
--- a/Assets/Scripts/Buff.cs
+++ b/Assets/Scripts/Buff.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 public abstract class Buff
 {
@@ -6,6 +7,7 @@ public abstract class Buff
     public float Duration { get; }
     public UniqueMode UniqueMode { get; }
     public UnitMediator Caster { get; }
+    public event Action OnRemoved = delegate {};
 
     private float _elapsed;
 
@@ -26,7 +28,9 @@ public abstract class Buff
 
     public virtual void OnApply(UnitMediator mediator) { }
 
-    public virtual void OnRemove(UnitMediator mediator) { }
+    public virtual void OnRemove(UnitMediator mediator) {
+        OnRemoved();
+    }
 
     public virtual bool Update(float deltaTime, UnitMediator mediator)
     {

--- a/Assets/Scripts/CastContext.cs
+++ b/Assets/Scripts/CastContext.cs
@@ -1,4 +1,10 @@
 public class CastContext
 {
     public UnitController caster;
+    public NetworkedSkillInstance skillInstance;
+    public CastContext(UnitController caster, NetworkedSkillInstance skillInstance)
+    {
+        this.caster = caster;
+        this.skillInstance = skillInstance;
+    }
 }

--- a/Assets/Scripts/NetworkedSkillInstance.cs
+++ b/Assets/Scripts/NetworkedSkillInstance.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 using Mirror;
 using UnityEngine;
@@ -13,6 +14,9 @@ public class NetworkedSkillInstance : NetworkBehaviour
     public SkillData skillData;
     private UnitController unit;
     private SkillDatabase skillDatabase;
+
+    [SerializeField]
+    public readonly List<(UnitMediator target, Buff buff)> appliedBuffs = new();
 
     public void Initialize(string name, UnitController unitRef)
     {
@@ -45,12 +49,61 @@ public class NetworkedSkillInstance : NetworkBehaviour
     public float CooldownProgress => (CooldownRemaining / skillData.cooldown) * 100f;
 
     [Server]
+    public void TriggerInit() {
+        if (skillData == null) return;
+        skillData.TriggerInit(new CastContext(unit, this));
+    }
+
+    [Server]
     public void Cast()
     {
         if (IsOnCooldown || skillData == null) return;
 
         lastCastTime = NetworkTime.time;
-        skillData.TriggerCast(unit);
+        CastContext castContext = new CastContext(unit, this);
+        skillData.TriggerCast(castContext);
+    }
+
+    [Server]
+    public void ManageBuff(UnitMediator mediator, Buff buff, bool apply)
+    {
+        if (apply)
+        {
+            mediator.AddBuff(buff);
+            appliedBuffs.Add((mediator, buff));
+
+            // Subscribe to OnRemoved only once
+            buff.OnRemoved += () => RemoveManagedBuff(mediator, buff);
+        }
+        else
+        {
+            mediator.Buffs.RemoveBuff(buff);
+
+            // Unsubscribe from the OnRemoved event
+            buff.OnRemoved -= () => RemoveManagedBuff(mediator, buff);
+            appliedBuffs.Remove((mediator, buff));
+        }
+    }
+
+    // Separate method for clean removal logic
+    [Server]
+    private void RemoveManagedBuff(UnitMediator mediator, Buff buff)
+    {
+        appliedBuffs.Remove((mediator, buff));
+        buff.OnRemoved -= () => RemoveManagedBuff(mediator, buff);
+    }
+
+    [Server]
+    public void Cleanup()
+    {
+         var buffsToRemove = new List<(UnitMediator target, Buff buff)>(appliedBuffs);
+
+        foreach (var (target, buff) in buffsToRemove)
+        {
+            ManageBuff(target, buff, false);
+        }
+
+        appliedBuffs.Clear();
     }
 
     [ContextMenu("Benchmark Cast 100,000x")]
@@ -61,7 +114,8 @@ public class NetworkedSkillInstance : NetworkBehaviour
         var stopwatch = Stopwatch.StartNew();
         for (int i = 0; i < 100000; i++)
         {
-            skillData.TriggerCast(unit);
+            CastContext castContext = new CastContext(unit, this);
+            skillData.TriggerCast(castContext);
         }
         stopwatch.Stop();
         UnityEngine.Debug.Log($"TriggerCast 100.000x: {stopwatch.ElapsedMilliseconds} ms");

--- a/Assets/Scripts/ScriptableObjects/SkillData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillData.cs
@@ -18,14 +18,14 @@ public class SkillData : ScriptableObject
     [Header("UI")]
     public Texture2D iconTexture;
 
-    public void TriggerInit(UnitController caster)
+    public void TriggerInit(CastContext castContext)
     {
-        initTrigger?.Execute(caster, new List<UnitController> { caster });
+        initTrigger?.Execute(castContext, new List<UnitController> { castContext.caster });
     }
 
-    public void TriggerCast(UnitController caster)
+    public void TriggerCast(CastContext castContext)
     {
-        castTrigger?.Execute(caster, new List<UnitController> { caster });
+        castTrigger?.Execute(castContext, new List<UnitController> { castContext.caster });
     }
 }
 

--- a/Assets/Scripts/ScriptableObjects/SkillEffectChainData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectChainData.cs
@@ -7,11 +7,11 @@ public class SkillEffectChainData : ScriptableObject
     [SerializeReference]
     public List<SkillEffectNodeData> rootNodes = new(); 
 
-    public void Execute(UnitController caster, List<UnitController> targets)
+    public void Execute(CastContext castContext, List<UnitController> targets)
     {
         foreach (var rootNode in rootNodes)
         {
-            rootNode.Execute(caster, targets);
+            rootNode.Execute(castContext, targets);
         }
     }
 }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectCondition.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectCondition.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 public abstract class SkillEffectCondition : SkillEffectData
 {
     public override SkillEffectType EffectType { get; } = SkillEffectType.Condition;
-    public override List<UnitController> Execute(UnitController caster, List<UnitController> targets) {
+    public override List<UnitController> Execute(CastContext castContext, List<UnitController> targets) {
         List<UnitController> result = new List<UnitController>();
         foreach (var target in targets)
         {
-            var isConditionMet = IsConditionMet(caster, target);
+            var isConditionMet = IsConditionMet(castContext, target);
             if (isConditionMet)
             {
                 result.Add(target);
@@ -16,5 +16,5 @@ public abstract class SkillEffectCondition : SkillEffectData
         return result;
     }
 
-    public abstract bool IsConditionMet(UnitController caster, UnitController target);
+    public abstract bool IsConditionMet(CastContext castContext, UnitController target);
 }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectConditionLowHealth.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectConditionLowHealth.cs
@@ -5,7 +5,7 @@ public class SkillEffectConditionLowHealthData : SkillEffectCondition
 {
     public float thresholdPercent = 0.5f;
 
-    public override bool IsConditionMet(UnitController caster, UnitController target)
+    public override bool IsConditionMet(CastContext castContext, UnitController target)
     {
         var health = target.health;
         var maxHealth = target.maxHealth;

--- a/Assets/Scripts/ScriptableObjects/SkillEffectData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectData.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 public abstract class SkillEffectData : ScriptableObject
 {
     public abstract SkillEffectType EffectType { get; }
-    public abstract List<UnitController> Execute(UnitController caster, List<UnitController> targets);
+    public abstract List<UnitController> Execute(CastContext castContext, List<UnitController> targets);
 }
 
 public enum SkillEffectType

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanic.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanic.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 public abstract class SkillEffectMechanic : SkillEffectData
 {
     public override SkillEffectType EffectType { get; } = SkillEffectType.Mechanic;
-    public override List<UnitController> Execute(UnitController caster, List<UnitController> targets) {
-        return DoMechanic(caster, targets);
+    public override List<UnitController> Execute(CastContext castContext, List<UnitController> targets) {
+        return DoMechanic(castContext, targets);
     }
 
-    public abstract List<UnitController> DoMechanic(UnitController caster, List<UnitController> targets);
+    public abstract List<UnitController> DoMechanic(CastContext castContext, List<UnitController> targets);
 
 
 }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicBuffStatData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicBuffStatData.cs
@@ -11,7 +11,7 @@ public class SkillEffectMechanicBuffStatData : SkillEffectMechanic
     public float duration = 5f;
     public UniqueMode uniqueMode = UniqueMode.None;
 
-    public override List<UnitController> DoMechanic(UnitController caster, List<UnitController> targets)
+    public override List<UnitController> DoMechanic(CastContext castContext, List<UnitController> targets)
     {
         foreach (var target in targets)
         {
@@ -21,7 +21,6 @@ public class SkillEffectMechanicBuffStatData : SkillEffectMechanic
                 Debug.LogWarning($"Target {target.name} does not have a UnitMediator component.");
                 continue;
             }
-
             var listStatModifiers = new List<StatModifier>
             {
                 new StatModifier() {
@@ -31,8 +30,8 @@ public class SkillEffectMechanicBuffStatData : SkillEffectMechanic
                 }
             };
 
-            BuffStat buff = new BuffStat(buffId, duration, listStatModifiers, uniqueMode, caster.unitMediator);
-            mediator.AddBuff(buff);
+            BuffStat buff = new BuffStat(buffId, duration, listStatModifiers, uniqueMode, castContext.caster.unitMediator);
+            castContext.skillInstance.ManageBuff(mediator, buff, true);
             Debug.Log($"Applied BuffStat to {target.name}: {StatType}, {ModifierType}, {Value}");
         }
         return targets;

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicDamageData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicDamageData.cs
@@ -6,12 +6,12 @@ public class SkillEffectMechanicDamageData : SkillEffectMechanic
 {
     public int amount = 20;
 
-    public override List<UnitController> DoMechanic(UnitController caster, List<UnitController> targets)
+    public override List<UnitController> DoMechanic(CastContext castContext, List<UnitController> targets)
     {
         Debug.Log($"Executing Damage Effect on {targets.Count} targets.");
         foreach (var target in targets)
         {
-            target.TakeDamage(amount, caster);
+            target.TakeDamage(amount, castContext.caster);
             Debug.Log($"Damaged {target.name} for {amount} health.");
         }
         return targets;

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicHealEffect.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicHealEffect.cs
@@ -6,7 +6,7 @@ public class SkillEffectMechanicHeal : SkillEffectMechanic
 {
     public int healAmount = 20;
 
-    public override List<UnitController> DoMechanic(UnitController caster, List<UnitController> targets)
+    public override List<UnitController> DoMechanic(CastContext castContext, List<UnitController> targets)
     {
         Debug.Log($"Executing Heal Effect on {targets.Count} targets.");
         foreach (var target in targets)

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicHealOverTime.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicHealOverTime.cs
@@ -11,7 +11,7 @@ public class SkillEffectMechanicHealOverTime : SkillEffectMechanic
     public  float tickInterval;
     public UniqueMode uniqueMode = UniqueMode.None;
 
-    public override List<UnitController> DoMechanic(UnitController caster, List<UnitController> targets)
+    public override List<UnitController> DoMechanic(CastContext castContext, List<UnitController> targets)
     {
         Debug.Log($"Executing Heal Over Time Effect on {targets.Count} targets.");
         foreach (var target in targets)
@@ -30,10 +30,9 @@ public class SkillEffectMechanicHealOverTime : SkillEffectMechanic
                 healAmount,
                 modifierType,
                 uniqueMode,
-                caster.unitMediator
+                castContext.caster.unitMediator
             );
-
-            mediator.AddBuff(buff);
+            castContext.skillInstance.ManageBuff(mediator, buff, true);
             Debug.Log($"Applied Heal Over Time to {target.name}: {healAmount} every {tickInterval} seconds.");
         }
         return targets;

--- a/Assets/Scripts/ScriptableObjects/SkillEffectNodeData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectNodeData.cs
@@ -11,14 +11,14 @@ public class SkillEffectNodeData
     [SerializeReference]
     public List<SkillEffectNodeData> children = new List<SkillEffectNodeData>();
 
-    public void Execute(UnitController caster, List<UnitController> targets)
+    public void Execute(CastContext castContext, List<UnitController> targets)
     {
         if (effect == null) return;
 
-        List<UnitController> nextTargets = effect.Execute(caster, targets);
+        List<UnitController> nextTargets = effect.Execute(castContext, targets);
         foreach (var child in children)
         {
-            child.Execute(caster, nextTargets);
+            child.Execute(castContext, nextTargets);
         }
     }
 }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectTarget.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectTarget.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 public abstract class SkillEffectTarget : SkillEffectData
 {
     public override SkillEffectType EffectType { get; } = SkillEffectType.Target;
-    public override List<UnitController> Execute(UnitController caster, List<UnitController> targets) {
-        return GetTargets(caster, targets);
+    public override List<UnitController> Execute(CastContext castContext, List<UnitController> targets) {
+        return GetTargets(castContext, targets);
     }
 
-    public abstract List<UnitController> GetTargets(UnitController caster, List<UnitController> targets);
+    public abstract List<UnitController> GetTargets(CastContext castContext, List<UnitController> targets);
 }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectTargetConeData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectTargetConeData.cs
@@ -8,21 +8,21 @@ public class SkillEffectTargetCone : SkillEffectTarget
     public float angle = 45f;
     public LayerMask unitLayer;
 
-    public override List<UnitController> GetTargets(UnitController caster, List<UnitController> targets)
+    public override List<UnitController> GetTargets(CastContext castContext, List<UnitController> targets)
     {
         List<UnitController> result = new List<UnitController>();
 
 
-        int casterTeam = caster.team;
-        Vector3 casterPosition = caster.transform.position;
-        Vector3 forward = caster.transform.forward;
+        int casterTeam = castContext.caster.team;
+        Vector3 casterPosition = castContext.caster.transform.position;
+        Vector3 forward = castContext.caster.transform.forward;
 
         // Get all colliders in range
         Collider[] hits = Physics.OverlapSphere(casterPosition, range, unitLayer);
         foreach (var hit in hits)
         {
             GameObject obj = hit.gameObject;
-            if (obj == caster) continue;
+            if (obj == castContext.caster) continue;
 
             UnitController unit = obj.GetComponent<UnitController>();
             if (unit == null) continue;
@@ -41,10 +41,10 @@ public class SkillEffectTargetCone : SkillEffectTarget
         }
 
 #if UNITY_EDITOR
-        SkillEffectTargetConeDebugDrawer drawer = caster.GetComponent<SkillEffectTargetConeDebugDrawer>();
+        SkillEffectTargetConeDebugDrawer drawer = castContext.caster.GetComponent<SkillEffectTargetConeDebugDrawer>();
         if (drawer == null)
         {
-            drawer = caster.gameObject.AddComponent<SkillEffectTargetConeDebugDrawer>();
+            drawer = castContext.caster.gameObject.AddComponent<SkillEffectTargetConeDebugDrawer>();
         }
 
         drawer.origin = casterPosition;

--- a/Assets/Scripts/ScriptableObjects/SkillEffectTargetLinearData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectTargetLinearData.cs
@@ -9,13 +9,13 @@ public class SkillEffectTargetLinear : SkillEffectTarget
     public LayerMask unitLayer;
 
 
-    public override List<UnitController> GetTargets(UnitController caster, List<UnitController> targets)
+    public override List<UnitController> GetTargets(CastContext castContext, List<UnitController> targets)
     {
         List<UnitController> result = new List<UnitController>();
 
 
-        Vector3 origin = caster.transform.position + Vector3.up;
-        Vector3 direction = caster.transform.forward;
+        Vector3 origin = castContext.caster.transform.position + Vector3.up;
+        Vector3 direction = castContext.caster.transform.forward;
 
         RaycastHit[] hits = Physics.SphereCastAll(origin, width / 2f, direction, range, unitLayer);
 
@@ -24,9 +24,9 @@ public class SkillEffectTargetLinear : SkillEffectTarget
             UnitController targetController = hit.collider.GetComponentInParent<UnitController>();
 
             if (targetController != null &&
-                targetController != caster &&
+                targetController != castContext.caster &&
                 !targetController.IsDead &&
-                targetController.team != caster.team)
+                targetController.team != castContext.caster.team)
             {
                 if (!result.Contains(targetController))
                 {
@@ -36,10 +36,10 @@ public class SkillEffectTargetLinear : SkillEffectTarget
         }
 
 #if UNITY_EDITOR
-        SkillEffectTargetLinearDebugDrawer drawer = caster.GetComponent<SkillEffectTargetLinearDebugDrawer>();
+        SkillEffectTargetLinearDebugDrawer drawer = castContext.caster.GetComponent<SkillEffectTargetLinearDebugDrawer>();
         if (drawer == null)
         {
-            drawer = caster.gameObject.AddComponent<SkillEffectTargetLinearDebugDrawer>();
+            drawer = castContext.caster.gameObject.AddComponent<SkillEffectTargetLinearDebugDrawer>();
         }
 
         drawer.origin = origin;

--- a/Assets/Scripts/SkillSystem.cs
+++ b/Assets/Scripts/SkillSystem.cs
@@ -39,12 +39,12 @@ public class SkillSystem : NetworkBehaviour
     [Server]
     private void InitializeSlots()
     {
-        //AddSkill(SkillSlotType.Passive, "HealingLeaf");
+        AddSkill(SkillSlotType.Passive, "HealingLeaf");
         AddSkill(SkillSlotType.Normal, "ConeOfCold");
         AddSkill(SkillSlotType.Normal, "IceBlast");
         AddSkill(SkillSlotType.Normal, "Swiftness");
         AddSkill(SkillSlotType.Ultimate, "HealingLeaf");
-        //RemoveSkill(SkillSlotType.Passive, 0);
+        RemoveSkill(SkillSlotType.Passive, 0);
     }
 
     [Server]
@@ -80,8 +80,7 @@ public class SkillSystem : NetworkBehaviour
                 ultimateSkills.Add(netSkill);
                 break;
         }
-
-        netSkill.skillData.TriggerInit(unit);
+        netSkill.TriggerInit();
     }
 
     [Server]
@@ -92,6 +91,7 @@ public class SkillSystem : NetworkBehaviour
 
         var skillToRemove = list[index];
         list.RemoveAt(index);
+        skillToRemove.Cleanup();
 
         if (skillToRemove != null && skillToRemove.gameObject != null)
         {
@@ -136,17 +136,18 @@ public class SkillSystem : NetworkBehaviour
     [Server]
     public void OnUnitRevive()
     {
+        Debug.Log("Unit revived, reinitializing skills.");
         foreach (var skill in passiveSkills)
         {
-            skill.skillData.TriggerInit(unit);
+            skill.TriggerInit();
         }
         foreach (var skill in normalSkills)
         {
-            skill.skillData.TriggerInit(unit);
+            skill.TriggerInit();
         }
         foreach (var skill in ultimateSkills)
         {
-            skill.skillData.TriggerInit(unit);
+            skill.TriggerInit();
         }
     }
 }


### PR DESCRIPTION
Replace UnitController caster parameters with CastContext in skill effect
execution methods to provide more contextual information during skill casting.
Update NetworkedSkillInstance to create and pass CastContext when triggering
skills. Adjust debug drawer components to access caster via CastContext.
This change improves extensibility and consistency across skill effect logic.