### PR TITLE
fix(buff): make OnRemoved event nullable and update invocation

### DIFF
--- a/Assets/Scripts/Buff.cs
+++ b/Assets/Scripts/Buff.cs
@@ -7,7 +7,7 @@ public abstract class Buff
     public float Duration { get; }
     public UniqueMode UniqueMode { get; }
     public UnitMediator Caster { get; }
-    public event Action OnRemoved = delegate {};
+    public event Action OnRemoved;
 
     private float _elapsed;
 
@@ -29,7 +29,7 @@ public abstract class Buff
     public virtual void OnApply(UnitMediator mediator) { }
 
     public virtual void OnRemove(UnitMediator mediator) {
-        OnRemoved();
+        OnRemoved?.Invoke();
     }
 
     public virtual bool Update(float deltaTime, UnitMediator mediator)

--- a/Assets/Ui/UI Toolkit/PanelSettings.asset
+++ b/Assets/Ui/UI Toolkit/PanelSettings.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   m_ReferenceSpritePixelsPerUnit: 100
   m_PixelsPerUnit: 100
   m_Scale: 1
-  m_ReferenceDpi: 182
+  m_ReferenceDpi: 96
   m_FallbackDpi: 96
   m_ReferenceResolution: {x: 1200, y: 800}
   m_ScreenMatchMode: 0


### PR DESCRIPTION
 OnRemoved event to be nullable to avoid unnecessary default
delegate assignment. Update OnRemove method to invoke OnRemoved
safely using null-conditional operator to prevent potential null
reference exceptions.

fix(ui): set reference DPI to standard 96 for UI scaling

Adjust UI Toolkit PanelSettings asset to use a standard reference
DPI of 96 instead of 182 to ensure consistent UI scaling across
different display settings.