### PR TITLE
feat(ui): add tooltip support to AbilityCooldownElement

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/ConeOfCold.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/ConeOfCold.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   skillName: ConeOfCold
   skillType: 0
-  description: 
+  description: Does damage to all enemy in a cone in front of you.
   cooldown: 7
   castCost: 0
   initTrigger: {fileID: 0}

--- a/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeaf.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/HealingLeaf/HealingLeaf.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   skillName: HealingLeaf
   skillType: 0
-  description: 
+  description: Heals over Time
   cooldown: 3
   castCost: 0
   initTrigger: {fileID: 0}

--- a/Assets/Resources/ScriptableObjects/Skills/IceBlast.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/IceBlast.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   skillName: IceBlast
   skillType: 0
-  description: 
+  description: Makes damage to all enemy in a line in front of you.
   cooldown: 10
   castCost: 0
   initTrigger: {fileID: 0}

--- a/Assets/Resources/ScriptableObjects/Skills/Swiftness.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/Swiftness.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   skillName: Swiftness
   skillType: 0
-  description: 
+  description: Makes you fast.
   cooldown: 8
   castCost: 0
   initTrigger: {fileID: 0}

--- a/Assets/Scripts/UiDocumentZombieIngameController.cs
+++ b/Assets/Scripts/UiDocumentZombieIngameController.cs
@@ -98,6 +98,7 @@ public class UiDocumentZombieIngameController : MonoBehaviour
             _skillPassive.CooldownRemaining = skillPassive.CooldownRemaining;
             _skillPassive.CooldownProgress = skillPassive.CooldownProgress;
             _skillPassive.IconTexture = skillPassive.skillData.iconTexture;
+            _skillPassive.TooltipText = $"{skillPassive.skillData.skillName}\n{skillPassive.skillData.description}";
         }
 
         var skill1 = _myPlayerUnitSkillSystem.GetSkill(SkillSlotType.Normal, 0);
@@ -106,6 +107,7 @@ public class UiDocumentZombieIngameController : MonoBehaviour
             _skillNormal1.CooldownRemaining = skill1.CooldownRemaining;
             _skillNormal1.CooldownProgress = skill1.CooldownProgress;
             _skillNormal1.IconTexture = skill1.skillData.iconTexture;
+            _skillNormal1.TooltipText = $"{skill1.skillData.skillName}\n{skill1.skillData.description}";
         }
 
         var skill2 = _myPlayerUnitSkillSystem.GetSkill(SkillSlotType.Normal, 1);
@@ -114,6 +116,7 @@ public class UiDocumentZombieIngameController : MonoBehaviour
             _skillNormal2.CooldownRemaining = skill2.CooldownRemaining;
             _skillNormal2.CooldownProgress = skill2.CooldownProgress;
             _skillNormal2.IconTexture = skill2.skillData.iconTexture;
+            _skillNormal2.TooltipText = $"{skill2.skillData.skillName}\n{skill2.skillData.description}";
         }
 
         var skill3 = _myPlayerUnitSkillSystem.GetSkill(SkillSlotType.Normal, 2);
@@ -122,6 +125,7 @@ public class UiDocumentZombieIngameController : MonoBehaviour
             _skillNormal3.CooldownRemaining = skill3.CooldownRemaining;
             _skillNormal3.CooldownProgress = skill3.CooldownProgress;
             _skillNormal3.IconTexture = skill3.skillData.iconTexture;
+            _skillNormal3.TooltipText = $"{skill3.skillData.skillName}\n{skill3.skillData.description}";
         }
 
         var skillUltimate = _myPlayerUnitSkillSystem.GetSkill(SkillSlotType.Ultimate, 0);
@@ -130,6 +134,7 @@ public class UiDocumentZombieIngameController : MonoBehaviour
             _skillUltimate.CooldownRemaining = skillUltimate.CooldownRemaining;
             _skillUltimate.CooldownProgress = skillUltimate.CooldownProgress;
             _skillUltimate.IconTexture = skillUltimate.skillData.iconTexture;
+            _skillUltimate.TooltipText = $"{skillUltimate.skillData.skillName}\n{skillUltimate.skillData.description}";
         }
 
     }


### PR DESCRIPTION
Add a TooltipText property to AbilityCooldownElement and display a tooltip
label on pointer hover. This improves user experience by showing skill name
and description when hovering over ability icons.

Update UiDocumentZombieIngameController to set TooltipText for each skill
based on skill data, enabling dynamic tooltip content.

Fix minor formatting issues and add pickingMode to ensure pointer events
are received even without background.