### PR TITLE
fix(ui): update panel scale mode and reference resolution

### DIFF
--- a/Assets/Ui/UI Toolkit/PanelSettings.asset
+++ b/Assets/Ui/UI Toolkit/PanelSettings.asset
@@ -17,13 +17,13 @@ MonoBehaviour:
   m_TargetTexture: {fileID: 0}
   m_RenderMode: 0
   m_WorldSpaceLayer: 0
-  m_ScaleMode: 1
+  m_ScaleMode: 2
   m_ReferenceSpritePixelsPerUnit: 100
   m_PixelsPerUnit: 100
   m_Scale: 1
   m_ReferenceDpi: 96
   m_FallbackDpi: 96
-  m_ReferenceResolution: {x: 1200, y: 800}
+  m_ReferenceResolution: {x: 1920, y: 1080}
   m_ScreenMatchMode: 0
   m_Match: 0
   m_SortingOrder: 0


### PR DESCRIPTION
Change the panel scale mode from constant to constant physical size to
improve UI scaling consistency across different screen densities.

Increase the reference resolution from 1200x800 to 1920x1080 to better
match modern display standards and enhance visual fidelity.