### PR TITLE
feat(skill): convert skill effect execution to coroutines

### DIFF
--- a/Assets/Scripts/ScriptableObjects/SkillData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillData.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -18,14 +19,24 @@ public class SkillData : ScriptableObject
     [Header("UI")]
     public Texture2D iconTexture;
 
-    public void TriggerInit(CastContext castContext)
+    public IEnumerator ExecuteInitCoroutine(CastContext castContext)
     {
-        initTrigger?.Execute(castContext, new List<UnitController> { castContext.caster });
+        if (initTrigger == null) yield break;
+
+        var targets = new List<UnitController> { castContext.caster };
+        yield return castContext.skillInstance.StartCoroutine(
+            initTrigger.ExecuteCoroutine(castContext, targets)
+        );
     }
 
-    public void TriggerCast(CastContext castContext)
+    public IEnumerator ExecuteCastCoroutine(CastContext castContext)
     {
-        castTrigger?.Execute(castContext, new List<UnitController> { castContext.caster });
+        if (castTrigger == null) yield break;
+
+        var targets = new List<UnitController> { castContext.caster };
+        yield return castContext.skillInstance.StartCoroutine(
+            castTrigger.ExecuteCoroutine(castContext, targets)
+        );
     }
 }
 

--- a/Assets/Scripts/ScriptableObjects/SkillEffectChainData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectChainData.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -5,13 +7,30 @@ using UnityEngine;
 public class SkillEffectChainData : ScriptableObject
 {
     [SerializeReference]
-    public List<SkillEffectNodeData> rootNodes = new(); 
+    public List<SkillEffectNodeData> rootNodes = new();
 
-    public void Execute(CastContext castContext, List<UnitController> targets)
+    public IEnumerator ExecuteCoroutine(CastContext castContext, List<UnitController> targets)
     {
+        var handels = new List<Coroutine>();
+        var doneCount = 0;
+        Action onRootComplete = () => doneCount++;
         foreach (var rootNode in rootNodes)
         {
-            rootNode.Execute(castContext, targets);
+            handels.Add(castContext.skillInstance.StartCoroutine(
+                WaitOnRoot(rootNode, castContext, targets, onRootComplete)
+            ));
         }
+
+        while (doneCount < rootNodes.Count)
+        {
+            yield return null;
+        }
+
+    }
+
+    private IEnumerator WaitOnRoot(SkillEffectNodeData rootNode, CastContext castContext, List<UnitController> targets, Action onComplete)
+    {
+        yield return rootNode.ExecuteCoroutine(castContext, targets);
+        onComplete();
     }
 }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectCondition.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectCondition.cs
@@ -1,20 +1,36 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
 
 public abstract class SkillEffectCondition : SkillEffectData
 {
     public override SkillEffectType EffectType { get; } = SkillEffectType.Condition;
-    public override List<UnitController> Execute(CastContext castContext, List<UnitController> targets) {
-        List<UnitController> result = new List<UnitController>();
+    public override IEnumerator Execute(
+            CastContext castContext,
+            List<UnitController> targets,
+            Action<List<UnitController>> onComplete
+        )
+    {
+        // Run your existing condition filter
+        var result = new List<UnitController>();
         foreach (var target in targets)
         {
-            var isConditionMet = IsConditionMet(castContext, target);
-            if (isConditionMet)
-            {
+            if (IsConditionMet(castContext, target))
                 result.Add(target);
-            }
         }
-        return result;
+
+        // Hand back the filtered list
+        onComplete(result);
+
+        // End the coroutine
+        yield break;
     }
 
-    public abstract bool IsConditionMet(CastContext castContext, UnitController target);
+    /// <summary>
+    /// Returns true if this target should pass through the condition.
+    /// </summary>
+    public abstract bool IsConditionMet(
+        CastContext castContext,
+        UnitController target
+    );
 }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectData.cs
@@ -1,10 +1,12 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
 public abstract class SkillEffectData : ScriptableObject
 {
     public abstract SkillEffectType EffectType { get; }
-    public abstract List<UnitController> Execute(CastContext castContext, List<UnitController> targets);
+    public abstract IEnumerator Execute(CastContext castContext, List<UnitController> targets, Action<List<UnitController>> onComplete);
 }
 
 public enum SkillEffectType

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanic.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanic.cs
@@ -1,13 +1,31 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
 
 public abstract class SkillEffectMechanic : SkillEffectData
 {
     public override SkillEffectType EffectType { get; } = SkillEffectType.Mechanic;
-    public override List<UnitController> Execute(CastContext castContext, List<UnitController> targets) {
-        return DoMechanic(castContext, targets);
+
+    public override IEnumerator Execute(
+        CastContext castContext,
+        List<UnitController> targets,
+        Action<List<UnitController>> onComplete
+    )
+    {
+        // Run the old synchronous logic
+        var nextTargets = DoMechanic(castContext, targets);
+
+        // Immediately signal completion
+        onComplete(nextTargets);
+
+        // End the coroutine
+        yield break;
     }
 
-    public abstract List<UnitController> DoMechanic(CastContext castContext, List<UnitController> targets);
+    public abstract List<UnitController> DoMechanic(
+        CastContext castContext,
+        List<UnitController> targets
+    );
 
 
 }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectNodeData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectNodeData.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -11,14 +12,41 @@ public class SkillEffectNodeData
     [SerializeReference]
     public List<SkillEffectNodeData> children = new List<SkillEffectNodeData>();
 
-    public void Execute(CastContext castContext, List<UnitController> targets)
+    public IEnumerator ExecuteCoroutine(CastContext castContext, List<UnitController> targets)
     {
-        if (effect == null) return;
+        if (effect == null) yield break;
 
-        List<UnitController> nextTargets = effect.Execute(castContext, targets);
+        List<UnitController> nextTargets = null;
+        bool finished = false;
+
+        // 1) run the effect’s coroutine, passing it our onComplete callback
+        yield return castContext.skillInstance.StartCoroutine(
+            effect.Execute(castContext, targets, (result) =>
+            {
+                nextTargets = result;
+                finished = true;
+            })
+        );
+
+        // 2) wait for the effect to finish
+        while (!finished)
+        {
+            yield return null;
+        }
+
+        // 3) if the effect has children, run their coroutines
+        if (children.Count == 0) yield break;
+
+        // 4) if the effect has children, run their coroutines
+        if (nextTargets == null)
+        {
+            Debug.LogError("Next targets are null. Effect might not have been executed correctly.");
+            yield break;
+        }
+        
         foreach (var child in children)
         {
-            child.Execute(castContext, nextTargets);
+            yield return child.ExecuteCoroutine(castContext, nextTargets);
         }
     }
 }

--- a/Assets/Scripts/ScriptableObjects/SkillEffectTarget.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectTarget.cs
@@ -1,11 +1,25 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
 
 public abstract class SkillEffectTarget : SkillEffectData
 {
     public override SkillEffectType EffectType { get; } = SkillEffectType.Target;
-    public override List<UnitController> Execute(CastContext castContext, List<UnitController> targets) {
-        return GetTargets(castContext, targets);
+    public override IEnumerator Execute(
+            CastContext castContext,
+            List<UnitController> targets,
+            Action<List<UnitController>> onComplete
+        )
+    {
+        var nextTargets = GetTargets(castContext, targets);
+        // Signal that we’re done and hand back the found units
+        onComplete(nextTargets);
+        // End the coroutine
+        yield break;
     }
 
-    public abstract List<UnitController> GetTargets(CastContext castContext, List<UnitController> targets);
+    public abstract List<UnitController> GetTargets(
+        CastContext castContext,
+        List<UnitController> targets
+    );
 }


### PR DESCRIPTION
Refactor skill effect execution methods to use coroutines for async
processing. Change SkillEffectData and derived classes to support
IEnumerator-based Execute methods with completion callbacks. Update
SkillData to run init and cast triggers as coroutines, allowing yield
control during execution. Modify SkillEffectChainData to wait for all
root nodes to complete asynchronously. This enables better control over
skill effect timing and sequencing, improving flexibility for complex
skill behaviors.