### PR TITLE
feat(skill): add delay mechanic skill effect

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/SkillEffectMechanicDelay1s.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/SkillEffectMechanicDelay1s.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e633cd427ef04fe4980593130a2eade, type: 3}
+  m_Name: SkillEffectMechanicDelay1s
+  m_EditorClassIdentifier: 
+  delaySeconds: 1

--- a/Assets/Resources/ScriptableObjects/Skills/SkillEffectMechanicDelay1s.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Skills/SkillEffectMechanicDelay1s.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f443f64b386a145c7addbdc599b2d908
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicDelayData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicDelayData.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(
+    fileName = "SkillEffectMechanicDelay",
+    menuName = "Game/Skills/Effects/Mechanic/Delay"
+)]
+public class SkillEffectMechanicDelayData : SkillEffectData
+{
+    [Tooltip("Seconds to wait before continuing the chain.")]
+    public float delaySeconds = 1f;
+
+    public override SkillEffectType EffectType => SkillEffectType.Mechanic;
+
+    public override IEnumerator Execute(
+        CastContext castContext,
+        List<UnitController> targets,
+        Action<List<UnitController>> onComplete
+    )
+    {
+        // 1) Wait for the specified delay
+        yield return new WaitForSeconds(delaySeconds);
+
+        // 2) Hand back the same targets so the chain continues
+        onComplete(targets);
+    }
+}

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicDelayData.cs.meta
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicDelayData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7e633cd427ef04fe4980593130a2eade


### PR DESCRIPTION
Introduce SkillEffectMechanicDelayData to enable a delay in skill effect
chains. This new ScriptableObject waits for a specified number of seconds
before continuing the effect chain, allowing for timed pauses in skill
execution. This change improves control over skill timing and sequencing.