### PR TITLE
feat(skill): add cancellation support init and cast coroutines

### DIFF
--- a/Assets/Scripts/CastContext.cs
+++ b/Assets/Scripts/CastContext.cs
@@ -2,6 +2,13 @@ public class CastContext
 {
     public UnitController caster;
     public NetworkedSkillInstance skillInstance;
+
+    private bool _isCancelled = false;
+    public bool IsCancelled => _isCancelled;
+    public void Cancel()
+    {
+        _isCancelled = true;
+    }
     public CastContext(UnitController caster, NetworkedSkillInstance skillInstance)
     {
         this.caster = caster;

--- a/Assets/Scripts/NetworkedSkillInstance.cs
+++ b/Assets/Scripts/NetworkedSkillInstance.cs
@@ -67,6 +67,17 @@ public class NetworkedSkillInstance : NetworkBehaviour
         _runningInitCoroutine = StartCoroutine(skillData.ExecuteInitCoroutine(_runningInitContext));
     }
 
+    public void CancelInit()
+    {
+        _runningInitContext?.Cancel();
+        _runningInitContext = null;
+        if (_runningInitCoroutine != null)
+        {
+            StopCoroutine(_runningInitCoroutine);
+            _runningInitCoroutine = null;
+        }
+    }
+
     private Coroutine _runningCastCoroutine;
     private CastContext _runningCastContext;
 
@@ -82,6 +93,16 @@ public class NetworkedSkillInstance : NetworkBehaviour
         }
         _runningCastContext = new CastContext(unit, this);
         _runningCastCoroutine = StartCoroutine(skillData.ExecuteCastCoroutine(_runningCastContext));
+    }
+    public void CancelCast()
+    {
+        _runningCastContext?.Cancel();
+        _runningCastContext = null;
+        if (_runningCastCoroutine != null)
+        {
+            StopCoroutine(_runningCastCoroutine);
+            _runningCastCoroutine = null;
+        }
     }
 
     [Server]


### PR DESCRIPTION
Add CancelInit and CancelCast methods to NetworkedSkillInstance to allow
stopping the initialization and casting coroutines prematurely. Introduce
cancellation state in CastContext to track if a cast has been cancelled.

These changes improve control over skill execution flow, enabling
interruptions and better handling of skill lifecycle in networked scenarios.