### PR TITLE
feat(skill): add channel mechanic skill effect with move speed control

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/SkillEffectMechanicChannel2s.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/SkillEffectMechanicChannel2s.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 02d4628603b564108a7d43f9092f482b, type: 3}
+  m_Name: SkillEffectMechanicChannel2s
+  m_EditorClassIdentifier: 
+  channelDuration: 2
+  moveSpeedPercent: 0.138

--- a/Assets/Resources/ScriptableObjects/Skills/SkillEffectMechanicChannel2s.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Skills/SkillEffectMechanicChannel2s.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 608e9b2423db1411980935c3ec5bc22e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicChannelData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicChannelData.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(
+    fileName = "SkillEffectMechanicChannel",
+    menuName = "Game/Skills/Effects/Mechanic/Channel"
+)]
+public class SkillEffectMechanicChannelData : SkillEffectData
+{
+    [Tooltip("Seconds to channel before continuing.")]
+    public float channelDuration = 2f;
+
+    [Tooltip("Percentage (0–1) of the caster’s base move speed allowed during channel.")]
+    [Range(0f, 1f)]
+    public float moveSpeedPercent = 0f;
+
+    public override SkillEffectType EffectType => SkillEffectType.Mechanic;
+
+    public override IEnumerator Execute(
+        CastContext ctx,
+        List<UnitController> targets,
+        Action<List<UnitController>> onComplete
+    )
+    {
+        var caster = ctx.caster;
+        StatModifier moveSpeedModifier = new StatModifier() {
+            Type = StatType.MovementSpeed,
+            ModifierType = ModifierType.Percent,
+            Value = moveSpeedPercent - 1f
+        };
+        caster.unitMediator.Stats.ApplyModifier(moveSpeedModifier);
+
+        float elapsed = 0f;
+        while (elapsed < channelDuration)
+        {
+            if (ctx.IsCancelled)
+            {
+                break;
+            }
+
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+
+        // Remove the move speed modifier
+        caster.unitMediator.Stats.RemoveModifier(moveSpeedModifier);
+        // Hand back the same targets so the chain continues
+        if (ctx.IsCancelled) yield break;
+
+        onComplete(targets);
+    }
+}

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicChannelData.cs.meta
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicChannelData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 02d4628603b564108a7d43f9092f482b


### PR DESCRIPTION
Introduce SkillEffectMechanicChannelData to enable skills that require
a channeling period before execution continues. During channeling, the
caster's movement speed is reduced by a configurable percentage. This
mechanic supports cancellation and ensures modifiers are properly applied
and removed. Add corresponding asset and meta files for integration.