### PR TITLE
feat(vfx): add linear area VFX spawning with mesh and material

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/IceBlastSkillEffectChain.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/IceBlastSkillEffectChain.asset
@@ -13,17 +13,29 @@ MonoBehaviour:
   m_Name: IceBlastSkillEffectChain
   m_EditorClassIdentifier: 
   rootNodes:
-  - rid: 5250463939730342002
+  - rid: 5250464128112001144
+  - rid: 5250464128112001147
   references:
     version: 2
     RefIds:
-    - rid: 5250463939730342002
+    - rid: 5250464128112001144
+      type: {class: SkillEffectNodeData, ns: , asm: Assembly-CSharp}
+      data:
+        effect: {fileID: 11400000, guid: 41856641b16ef43f592ed2770bb0d4e2, type: 2}
+        children: []
+    - rid: 5250464128112001147
+      type: {class: SkillEffectNodeData, ns: , asm: Assembly-CSharp}
+      data:
+        effect: {fileID: 11400000, guid: 608e9b2423db1411980935c3ec5bc22e, type: 2}
+        children:
+        - rid: 5250464128112001148
+    - rid: 5250464128112001148
       type: {class: SkillEffectNodeData, ns: , asm: Assembly-CSharp}
       data:
         effect: {fileID: 11400000, guid: f6db72ab086e3447eb33a0bdd2b2f1a0, type: 2}
         children:
-        - rid: 5250463939730342015
-    - rid: 5250463939730342015
+        - rid: 5250464128112001149
+    - rid: 5250464128112001149
       type: {class: SkillEffectNodeData, ns: , asm: Assembly-CSharp}
       data:
         effect: {fileID: 11400000, guid: 5c4ffd98e94074aa5a09a5c8ac9682b8, type: 2}

--- a/Assets/Resources/ScriptableObjects/Skills/IceBlastVFX.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/IceBlastVFX.asset
@@ -9,8 +9,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 02d4628603b564108a7d43f9092f482b, type: 3}
-  m_Name: SkillEffectMechanicChannel2s
+  m_Script: {fileID: 11500000, guid: 2e8afcf9dee6b4295823b5da5f340240, type: 3}
+  m_Name: IceBlastVFX
   m_EditorClassIdentifier: 
-  channelDuration: 2
-  moveSpeedPercent: 0.7
+  range: 20
+  width: 2
+  materialResourcePath: Materials/VFX/LinearAreaHighlight
+  duration: 2

--- a/Assets/Resources/ScriptableObjects/Skills/IceBlastVFX.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Skills/IceBlastVFX.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 41856641b16ef43f592ed2770bb0d4e2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MeshFactory.cs
+++ b/Assets/Scripts/MeshFactory.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class MeshFactory
+{
+    /// <summary>
+    /// Builds a flat quad (XZ plane) of length `range` (Z) and width `width` (X),
+    /// centered on the local origin. If flipWinding=true, its normals face down.
+    /// </summary>
+    public static Mesh BuildRectangle(float range, float width, bool flipWinding = false)
+    {
+        float hr = range * 0.5f;
+        float hw = width * 0.5f;
+
+        Vector3[] verts = {
+            new(-hw, 0f, -hr), // 0 back-left
+            new( hw, 0f, -hr), // 1 back-right
+            new( hw, 0f,  hr), // 2 front-right
+            new(-hw, 0f,  hr), // 3 front-left
+        };
+
+        int[] tris = flipWinding
+            // face down: reverse winding
+            ? new[]{ 0, 2, 1,  2, 0, 3 }
+            // face up: normal winding
+            : new[]{ 0, 1, 2,  2, 3, 0 };
+
+        Vector2[] uvs = {
+            new(0,0), new(1,0), new(1,1), new(0,1)
+        };
+
+        var m = new Mesh();
+        m.name      = "Procedural_Rectangle";
+        m.vertices  = verts;
+        m.triangles = tris;
+        m.uv        = uvs;
+        m.RecalculateNormals();
+        return m;
+    }
+}

--- a/Assets/Scripts/MeshFactory.cs.meta
+++ b/Assets/Scripts/MeshFactory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f63761bfd03145e79313e3ec7fc0ca6

--- a/Assets/Scripts/MeshVFXSpawner.cs
+++ b/Assets/Scripts/MeshVFXSpawner.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+public static class MeshVFXSpawner
+{
+    public static void Spawn(
+        Mesh mesh,
+        Material mat,
+        Vector3 position,
+        Quaternion rotation,
+        float duration,
+        Transform parent = null)
+    {
+        var go = new GameObject("MeshVFX");
+        if (parent != null)
+        {
+            // make it a child, and treat position/rotation as local
+            go.transform.SetParent(parent, worldPositionStays: false);
+            go.transform.localPosition = position;
+            go.transform.localRotation = rotation;
+        }
+        else
+        {
+            go.transform.position = position;
+            go.transform.rotation = rotation;
+        }
+
+        var mf = go.AddComponent<MeshFilter>();
+        mf.mesh = mesh;
+        var mr = go.AddComponent<MeshRenderer>();
+        mr.material = mat;
+
+        Object.Destroy(go, duration);
+    }
+}
+

--- a/Assets/Scripts/MeshVFXSpawner.cs.meta
+++ b/Assets/Scripts/MeshVFXSpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 89361c6dec93a4c998c9b4a4f2654d9c

--- a/Assets/Scripts/SkillEffectTargetLinearVFX.cs
+++ b/Assets/Scripts/SkillEffectTargetLinearVFX.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Mirror;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Game/Skills/Effects/VFX/TargetLinearArea")]
+public class SkillEffectTargetLinearVFX : SkillEffectData
+{
+    [Tooltip("Same as your TargetLinear range/width")]
+    public float range = 5f;
+    public float width = 1f;
+
+    [Tooltip("Path under Resources to your unlit transparent VFX material")]
+    public string materialResourcePath = "Materials/VFX/LinearAreaHighlight";
+
+    [Tooltip("How long the spawned mesh should live")]
+    public float duration = 1f;
+
+    public override SkillEffectType EffectType => SkillEffectType.Mechanic;
+
+    public override IEnumerator Execute(CastContext ctx, List<UnitController> targets, Action<List<UnitController>> onComplete)
+    {
+        // Only the server (or host) should send the RPC out
+        if (NetworkServer.active)
+        {
+            Vector3 origin    = ctx.caster.transform.position + Vector3.up * 0.01f;
+            Vector3 direction = ctx.caster.transform.forward;
+
+            ctx.skillInstance.Rpc_SpawnLinearAreaVFX(
+                origin,
+                direction,
+                range,
+                width,
+                materialResourcePath,
+                duration);
+        }
+
+        // pass the (unchanged) targets back into the pipeline
+        onComplete(targets);
+        yield break;
+    }
+}

--- a/Assets/Scripts/SkillEffectTargetLinearVFX.cs.meta
+++ b/Assets/Scripts/SkillEffectTargetLinearVFX.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2e8afcf9dee6b4295823b5da5f340240


### PR DESCRIPTION
Introduce MeshVFXSpawner to spawn mesh-based VFX with specified material,
position, rotation, and duration. Add MeshFactory to create flat quads for
VFX geometry. Implement Rpc_SpawnLinearAreaVFX in NetworkedSkillInstance to
spawn a linear area VFX on clients using a generated quad and material.

Update skill data to increase move speed percent for channeling skills.

These changes enable flexible, networked visual effects for skills with
customizable appearance and lifetime.