### PR TITLE
feat: add turn speed stat and apply it to unit turning

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/ConeOfColdSkillChain.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/ConeOfColdSkillChain.asset
@@ -23,14 +23,14 @@ MonoBehaviour:
         effect: {fileID: 11400000, guid: bb6521ce3b31440ada56bcb4d36a35dd, type: 2}
         children:
         - rid: 5250463924834271353
+        - rid: 5250464195305799800
     - rid: 5250463924834271353
       type: {class: SkillEffectNodeData, ns: , asm: Assembly-CSharp}
       data:
         effect: {fileID: 11400000, guid: 52b6abc3b5f464a83bd79558b491617f, type: 2}
-        children:
-        - rid: 5250463924834271354
-    - rid: 5250463924834271354
+        children: []
+    - rid: 5250464195305799800
       type: {class: SkillEffectNodeData, ns: , asm: Assembly-CSharp}
       data:
-        effect: {fileID: 0}
+        effect: {fileID: 11400000, guid: 73b9567e2ec5d41d98192df848d1923e, type: 2}
         children: []

--- a/Assets/Resources/ScriptableObjects/Skills/Slow30Percent.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/Slow30Percent.asset
@@ -9,7 +9,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 626adc8cd51944bfda2721e51e8e7645, type: 3}
-  m_Name: DamageFor200
+  m_Script: {fileID: 11500000, guid: 4a02f08d0ddb34ad9bf5447f63ba90c5, type: 3}
+  m_Name: Slow30Percent
   m_EditorClassIdentifier: 
-  amount: 5
+  buffId: ConeOfCold
+  StatType: 1
+  ModifierType: 1
+  Value: 0.3
+  duration: 5
+  uniqueMode: 1

--- a/Assets/Resources/ScriptableObjects/Skills/Slow30Percent.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Skills/Slow30Percent.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73b9567e2ec5d41d98192df848d1923e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ScriptableObjects/Skills/SwiftnessSkillEffectBuffStatSpeed.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/SwiftnessSkillEffectBuffStatSpeed.asset
@@ -15,6 +15,6 @@ MonoBehaviour:
   buffId: Swiftness
   StatType: 1
   ModifierType: 1
-  Value: 0.5
+  Value: 1.5
   duration: 3
   uniqueMode: 1

--- a/Assets/Scripts/ScriptableObjects/SkillEffectMechanicChannelData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectMechanicChannelData.cs
@@ -16,6 +16,10 @@ public class SkillEffectMechanicChannelData : SkillEffectData
     [Range(0f, 1f)]
     public float moveSpeedPercent = 0f;
 
+    [Tooltip("Percentage (0-1) of the caster's base turn speed allowed during channel.")]
+    [Range(0f, 1f)]
+    public float turnSpeedPercent = 0f;
+
     public override SkillEffectType EffectType => SkillEffectType.Mechanic;
 
     public override IEnumerator Execute(
@@ -28,9 +32,16 @@ public class SkillEffectMechanicChannelData : SkillEffectData
         StatModifier moveSpeedModifier = new StatModifier() {
             Type = StatType.MovementSpeed,
             ModifierType = ModifierType.Percent,
-            Value = moveSpeedPercent - 1f
+            Value = moveSpeedPercent
         };
         caster.unitMediator.Stats.ApplyModifier(moveSpeedModifier);
+        
+        StatModifier turnSpeedModifier = new StatModifier() {
+            Type = StatType.TurnSpeed,
+            ModifierType = ModifierType.Percent,
+            Value = turnSpeedPercent
+        };
+        caster.unitMediator.Stats.ApplyModifier(turnSpeedModifier);
 
         float elapsed = 0f;
         while (elapsed < channelDuration)
@@ -46,6 +57,7 @@ public class SkillEffectMechanicChannelData : SkillEffectData
 
         // Remove the move speed modifier
         caster.unitMediator.Stats.RemoveModifier(moveSpeedModifier);
+        caster.unitMediator.Stats.RemoveModifier(turnSpeedModifier);
         // Hand back the same targets so the chain continues
         if (ctx.IsCancelled) yield break;
 

--- a/Assets/Scripts/StatModifier.cs
+++ b/Assets/Scripts/StatModifier.cs
@@ -3,6 +3,7 @@ public enum StatType
     Health,
     MovementSpeed,
     Shield,
+    TurnSpeed,
 }
 
 [System.Serializable]

--- a/Assets/Scripts/StatSystem.cs
+++ b/Assets/Scripts/StatSystem.cs
@@ -16,6 +16,7 @@ public class StatSystem
         baseStats[StatType.Health] = this.mediator.UnitController.maxHealth;
         baseStats[StatType.MovementSpeed] = this.mediator.UnitController.moveSpeed;
         baseStats[StatType.Shield] = this.mediator.UnitController.maxShield;
+        baseStats[StatType.TurnSpeed] = 1f;
     }
 
     public void SetBaseStat(StatType stat, float value)
@@ -54,7 +55,7 @@ public class StatSystem
             if (mod.ModifierType == ModifierType.Flat)
                 value += mod.Value;
             else if (mod.ModifierType == ModifierType.Percent)
-                value *= 1 + mod.Value;
+                value *= mod.Value;
         }
 
         return value;

--- a/Assets/Scripts/UnitController.cs
+++ b/Assets/Scripts/UnitController.cs
@@ -190,7 +190,12 @@ public class UnitController : NetworkBehaviour
     {
         if(IsDead) return;
 
-        float lerpedAngle = Mathf.LerpAngle(transform.rotation.eulerAngles.y, angle, Time.deltaTime * 10);
+        float turnSpeed = unitMediator.Stats.GetStat(StatType.TurnSpeed); // Should be in range [0,1]
+        if (turnSpeed <= 0f) return; // Do not turn if turnSpeed is 0
+
+        float currentY = transform.rotation.eulerAngles.y;
+        float targetY = angle;
+        float lerpedAngle = Mathf.LerpAngle(currentY, targetY, Time.deltaTime * 10 * turnSpeed);
         transform.rotation = Quaternion.AngleAxis(lerpedAngle, Vector3.up);
     }
 

--- a/Assets/Scripts/UnitMediator.cs
+++ b/Assets/Scripts/UnitMediator.cs
@@ -33,7 +33,8 @@ public class UnitMediator : NetworkBehaviour
                 UnitController.maxShield = (int)Stats.GetStat(StatType.Shield);
                 break;
             default:
-                throw new ArgumentOutOfRangeException(nameof(type), type, null);
+                Debug.LogWarning($"Stat {type} not handled in UnitMediator.");
+                break;
         }
     }
 

--- a/Assets/Scripts/WeaponController.cs
+++ b/Assets/Scripts/WeaponController.cs
@@ -36,7 +36,7 @@ public class WeaponController : NetworkBehaviour
         StatModifier moveSpeedModifier = new StatModifier() {
             Type = StatType.MovementSpeed,
             ModifierType = ModifierType.Percent,
-            Value = weaponData.moveSpeedPercentWhileAttacking - 1,
+            Value = weaponData.moveSpeedPercentWhileAttacking,
         };
         attacker.unitMediator.Stats.ApplyModifier(moveSpeedModifier);
         await Task.Delay((int)delay);


### PR DESCRIPTION
- Introduce TurnSpeed stat and integrate it into UnitController rotation logic
  to scale turning speed based on the stat value.
- Extend SkillEffectMechanicChannelData to apply and remove turn speed modifiers
  alongside movement speed modifiers during channeling effects.
- Fix StatSystem to correctly multiply percent modifiers without adding 1.
- Add new Slow30Percent skill asset and update existing skill assets to reflect
  adjusted stat values.
- Improve UnitMediator to handle unknown stat types gracefully with a warning.