### PR TITLE
feat(vfx): add offset support for skill effect target area VFX

### DIFF
--- a/Assets/Scripts/NetworkedSkillInstance.cs
+++ b/Assets/Scripts/NetworkedSkillInstance.cs
@@ -146,7 +146,8 @@ public class NetworkedSkillInstance : NetworkBehaviour
         string materialResourcePath,
         float duration,
         Transform target,
-        AreaVFXShape shape)
+        AreaVFXShape shape,
+        Vector2 offset)
     {
         Mesh mesh = shape switch
         {
@@ -157,8 +158,13 @@ public class NetworkedSkillInstance : NetworkBehaviour
         };
 
         Material mat = Resources.Load<Material>(materialResourcePath);
+        // Offset in the direction of 'direction' (forward) and its right vector
+        Vector3 forward = direction.normalized;
+        Vector3 right = Vector3.Cross(Vector3.up, forward).normalized;
 
-        Vector3 worldPos = origin;
+        Vector3 offsetPosition = forward * offset.y + right * offset.x;
+
+        Vector3 worldPos = origin + offsetPosition;
         if (shape == AreaVFXShape.Rectangle)
         {
             // For rectangle, center it at origin + forward * (range/2)

--- a/Assets/Scripts/ScriptableObjects/SkillEffectTargetAreaVFX.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectTargetAreaVFX.cs
@@ -10,6 +10,7 @@ public class SkillEffectTargetAreaVFX : SkillEffectData
     [Tooltip("Same as your TargetLinear range/width")]
     public float range = 5f;
     public float width = 1f;
+    public Vector2 offset = Vector2.zero;
 
     [Tooltip("Path under Resources to your unlit transparent VFX material")]
     public string materialResourcePath = "Materials/VFX/LinearAreaHighlight";
@@ -40,7 +41,8 @@ public class SkillEffectTargetAreaVFX : SkillEffectData
                     materialResourcePath,
                     duration,
                     target.transform,
-                    shape
+                    shape,
+                    offset
                 );
             }
         }


### PR DESCRIPTION
Add a Vector2 offset to SkillEffectTargetAreaVFX to allow adjusting the
position of the area VFX relative to the target. Update NetworkedSkillInstance
to apply this offset by calculating a world position shifted along the
forward and right vectors. This enables more precise placement of VFX shapes,
improving visual alignment and flexibility.