### PR TITLE
feat(vfx): add option to attach area VFX to target

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/ConeOfColdVFX.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/ConeOfColdVFX.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   range: 10
   width: 35
+  offset: {x: 0, y: 0}
   materialResourcePath: Materials/VFX/LinearAreaHighlight
   duration: 0.1
   shape: 2
+  attachToTarget: 0

--- a/Assets/Resources/ScriptableObjects/Skills/IceBlastVFX.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/IceBlastVFX.asset
@@ -14,6 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   range: 20
   width: 2
+  offset: {x: 0, y: 0}
   materialResourcePath: Materials/VFX/Placeholder
   duration: 1
   shape: 0
+  attachToTarget: 1

--- a/Assets/Scripts/NetworkedSkillInstance.cs
+++ b/Assets/Scripts/NetworkedSkillInstance.cs
@@ -147,7 +147,8 @@ public class NetworkedSkillInstance : NetworkBehaviour
         float duration,
         Transform target,
         AreaVFXShape shape,
-        Vector2 offset)
+        Vector2 offset,
+        bool attachToTarget)
     {
         Mesh mesh = shape switch
         {
@@ -175,14 +176,14 @@ public class NetworkedSkillInstance : NetworkBehaviour
         Vector3 localPos = worldPos;
         Quaternion localRot = worldRot;
 
-        if (target != null)
+        if (attachToTarget && target != null)
         {
             // Convert world to local
             localPos = target.InverseTransformPoint(worldPos);
             localRot = Quaternion.Inverse(target.rotation) * worldRot;
         }
 
-        MeshVFXSpawner.Spawn(mesh, mat, localPos, localRot, duration, target);
+        MeshVFXSpawner.Spawn(mesh, mat, localPos, localRot, duration, attachToTarget ? target : null);
     }
 
     [Server]

--- a/Assets/Scripts/ScriptableObjects/SkillEffectTargetAreaVFX.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillEffectTargetAreaVFX.cs
@@ -21,6 +21,8 @@ public class SkillEffectTargetAreaVFX : SkillEffectData
     [Tooltip("Shape of the area VFX")]
     public AreaVFXShape shape = AreaVFXShape.Rectangle;
 
+    public bool attachToTarget = true;
+
     public override SkillEffectType EffectType => SkillEffectType.Mechanic;
 
     public override IEnumerator Execute(CastContext ctx, List<UnitController> targets, Action<List<UnitController>> onComplete)
@@ -32,7 +34,7 @@ public class SkillEffectTargetAreaVFX : SkillEffectData
             {
                 Vector3 origin = target.transform.position;
                 Vector3 direction = target.transform.forward;
-            
+
                 ctx.skillInstance.Rpc_SpawnAreaVFX(
                     origin,
                     direction,
@@ -42,7 +44,8 @@ public class SkillEffectTargetAreaVFX : SkillEffectData
                     duration,
                     target.transform,
                     shape,
-                    offset
+                    offset,
+                    attachToTarget
                 );
             }
         }


### PR DESCRIPTION
Add a new attachToTarget flag to SkillEffectTargetAreaVFX and 
NetworkedSkillInstance to control whether area VFX should follow 
the target transform. This enables more flexible visual effects 
that can either remain static in world space or move with the target.

Update existing skill VFX assets to include the attachToTarget 
property with appropriate default values.