### PR TITLE
(zombie): increase werwolfs special wave intervalsIncrease the minimum and maximum interval for the "werwolfs"

### DIFF
--- a/Assets/Resources/ScriptableObjects/ZombieMode/ZombieModeConfig.asset
+++ b/Assets/Resources/ScriptableObjects/ZombieMode/ZombieModeConfig.asset
@@ -32,8 +32,8 @@ MonoBehaviour:
   waveOverrides: []
   recurringSpecialWaves:
   - ruleId: werwolfs
-    minInterval: 4
-    maxInterval: 6
+    minInterval: 6
+    maxInterval: 8
     replaceRegularWave: 1
     wave:
       waveName: Werwolfs


### PR DESCRIPTION
recurring special wave from4-6 to6-8. reduces how oftenthe werwolfs special can appear during a run, making theounter less frequent and easing difficulty spikes caused byback-back special waves.