### PR TITLE
feat(zombie): runs to leaderboard and track run startAdd leaderboard DTOs, a run submitter component, run timingtracking to support server-side run and centralized runend handling.

### DIFF
--- a/Assets/Scripts/Events/GameEvent.cs
+++ b/Assets/Scripts/Events/GameEvent.cs
@@ -65,6 +65,23 @@ namespace MyGame.Events
         }
     }
 
+    public enum ZombieRunEndReason
+    {
+        AllPlayersDead = 0,
+        HostEndedEarly = 1,
+        ReturnToLobbyAfterGameOver = 2
+    }
+
+    public class ZombieRunEndedEvent : GameEvent
+    {
+        public ZombieRunEndReason EndReason { get; }
+
+        public ZombieRunEndedEvent(ZombieRunEndReason endReason)
+        {
+            EndReason = endReason;
+        }
+    }
+
     /// <summary>
     /// Fired when a unit receives damage.
     /// </summary>

--- a/Assets/Scripts/Leaderboard.meta
+++ b/Assets/Scripts/Leaderboard.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1327bedf840539d46b085141d70a9503
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Leaderboard/ZombieLeaderboardModels.cs
+++ b/Assets/Scripts/Leaderboard/ZombieLeaderboardModels.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+[Serializable]
+public class ZombieRunPlayerDto
+{
+    public string nickname;
+    public int points;
+    public int zombieKills;
+    public int goldCollected;
+    public int deaths;
+}
+
+[Serializable]
+public class ZombieRunSubmitDto
+{
+    public string version;
+    public int playerCount;
+    public int wavesSurvived;
+    public int duration;
+    public int totalPoints;
+    public List<ZombieRunPlayerDto> players;
+}
+
+public static class ZombieLeaderboardVersionResolver
+{
+    public static string ResolveGameVersion()
+    {
+#if UNITY_EDITOR
+        return "0.0.0";
+#else
+        return string.IsNullOrWhiteSpace(UnityEngine.Application.version)
+            ? "0.0.0"
+            : UnityEngine.Application.version;
+#endif
+    }
+}

--- a/Assets/Scripts/Leaderboard/ZombieLeaderboardModels.cs.meta
+++ b/Assets/Scripts/Leaderboard/ZombieLeaderboardModels.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4f20a6f004f64114e88605b3927faee5

--- a/Assets/Scripts/Leaderboard/ZombieLeaderboardRunSubmitter.cs
+++ b/Assets/Scripts/Leaderboard/ZombieLeaderboardRunSubmitter.cs
@@ -1,0 +1,534 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Mirror;
+using MyGame.Events;
+using UnityEngine;
+using UnityEngine.Networking;
+
+[DefaultExecutionOrder(-850)]
+[DisallowMultipleComponent]
+public sealed class ZombieLeaderboardRunSubmitter : MonoBehaviour
+{
+    private const string DefaultBaseUrl = "https://leaderboard-api.shadowinfection.com";
+    private const int MaxPlayersPerRun = 5;
+    private static readonly Regex UnsafeNicknameChars = new Regex("[^a-zA-Z0-9 _\\-]", RegexOptions.Compiled);
+    private static ZombieLeaderboardRunSubmitter instance;
+
+    [SerializeField] private bool isSubmissionEnabled = true;
+    [SerializeField] private string baseUrl = DefaultBaseUrl;
+    [SerializeField] private int timeoutSeconds = 10;
+    [SerializeField] private int maxRetryAttempts = 3;
+    [SerializeField] private float initialRetryDelaySeconds = 1.5f;
+
+    private bool isSubscribed;
+    private bool isProcessingQueue;
+    private readonly Queue<QueuedSubmission> pendingSubmissions = new Queue<QueuedSubmission>();
+
+    private int runSequence;
+    private int activeRunSequence = -1;
+    private bool hasSubmittedForActiveRun;
+    private float fallbackRunStartTime;
+    private int nextSubmissionId = 1;
+
+    private CancellationTokenSource cts;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void EnsureBootstrapInstance()
+    {
+        var existing = FindAnyObjectByType<ZombieLeaderboardRunSubmitter>();
+        if (existing != null)
+        {
+            return;
+        }
+
+        var host = new GameObject(nameof(ZombieLeaderboardRunSubmitter));
+        host.AddComponent<ZombieLeaderboardRunSubmitter>();
+        DontDestroyOnLoad(host);
+    }
+
+    private void Awake()
+    {
+        if (instance != null && instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        instance = this;
+        DontDestroyOnLoad(gameObject);
+        cts = new CancellationTokenSource();
+    }
+
+    private void Update()
+    {
+        TrySubscribe();
+    }
+
+    private void OnDestroy()
+    {
+        if (instance == this)
+        {
+            instance = null;
+        }
+
+        Unsubscribe();
+
+        if (cts != null)
+        {
+            cts.Cancel();
+            cts.Dispose();
+            cts = null;
+        }
+    }
+
+    private void TrySubscribe()
+    {
+        if (isSubscribed)
+        {
+            return;
+        }
+
+        if (EventManager.Instance == null)
+        {
+            return;
+        }
+
+        EventManager.Instance.Subscribe<ZombieGameOverEvent>(HandleZombieGameOverEvent);
+        EventManager.Instance.Subscribe<ZombieRunEndedEvent>(HandleZombieRunEndedEvent);
+        isSubscribed = true;
+    }
+
+    private void Unsubscribe()
+    {
+        if (!isSubscribed || EventManager.Instance == null)
+        {
+            return;
+        }
+
+        EventManager.Instance.Unsubscribe<ZombieGameOverEvent>(HandleZombieGameOverEvent);
+        EventManager.Instance.Unsubscribe<ZombieRunEndedEvent>(HandleZombieRunEndedEvent);
+        isSubscribed = false;
+    }
+
+    private void HandleZombieGameOverEvent(ZombieGameOverEvent gameOverEvent)
+    {
+        if (!NetworkServer.active)
+        {
+            return;
+        }
+
+        if (!gameOverEvent.IsGameOver)
+        {
+            BeginRun();
+            return;
+        }
+
+        CaptureAndQueueIfNeeded(ZombieRunEndReason.AllPlayersDead);
+    }
+
+    private void HandleZombieRunEndedEvent(ZombieRunEndedEvent runEndedEvent)
+    {
+        if (!NetworkServer.active)
+        {
+            return;
+        }
+
+        CaptureAndQueueIfNeeded(runEndedEvent.EndReason);
+    }
+
+    private void BeginRun()
+    {
+        activeRunSequence = ++runSequence;
+        hasSubmittedForActiveRun = false;
+        fallbackRunStartTime = Time.time;
+    }
+
+    private void EnsureRunInitialized()
+    {
+        if (activeRunSequence >= 0)
+        {
+            return;
+        }
+
+        BeginRun();
+    }
+
+    private void CaptureAndQueueIfNeeded(ZombieRunEndReason reason)
+    {
+        if (!isSubmissionEnabled)
+        {
+            return;
+        }
+
+        EnsureRunInitialized();
+        if (hasSubmittedForActiveRun)
+        {
+            return;
+        }
+
+        if (!TryBuildSubmissionPayload(out var payload, out var payloadError))
+        {
+            Debug.LogWarning($"[{nameof(ZombieLeaderboardRunSubmitter)}] Skipping leaderboard submit: {payloadError}", this);
+            return;
+        }
+
+        hasSubmittedForActiveRun = true;
+
+        var queueItem = new QueuedSubmission
+        {
+            SubmissionId = nextSubmissionId++,
+            RunSequence = activeRunSequence,
+            EndReason = reason,
+            Payload = payload
+        };
+
+        pendingSubmissions.Enqueue(queueItem);
+        if (!isProcessingQueue)
+        {
+            _ = ProcessQueueAsync();
+        }
+    }
+
+    private bool TryBuildSubmissionPayload(out ZombieRunSubmitDto payload, out string error)
+    {
+        payload = null;
+        error = null;
+
+        var gameManager = ZombieGameManager.Singleton;
+        if (gameManager == null)
+        {
+            error = "ZombieGameManager not available.";
+            return false;
+        }
+
+        var players = new List<ZombieRunPlayerDto>();
+        int totalPoints = 0;
+
+        var entries = gameManager.LeaderboardEntries;
+        if (entries == null)
+        {
+            error = "Leaderboard entries unavailable.";
+            return false;
+        }
+
+        for (int i = 0; i < entries.Count; i++)
+        {
+            var row = entries[i];
+            if (row.ConnectionId < 0)
+            {
+                continue;
+            }
+
+            string nickname = string.IsNullOrWhiteSpace(row.PlayerName)
+                ? $"Player{row.ConnectionId}"
+                : row.PlayerName.Trim();
+
+            nickname = SanitizeNickname(nickname, row.ConnectionId);
+
+            if (nickname.Length > 32)
+            {
+                nickname = nickname.Substring(0, 32);
+            }
+
+            int points = Mathf.Max(0, row.Points);
+            players.Add(new ZombieRunPlayerDto
+            {
+                nickname = nickname,
+                points = points,
+                zombieKills = Mathf.Max(0, row.Kills),
+                goldCollected = Mathf.Max(0, row.GoldGathered),
+                deaths = Mathf.Max(0, row.Deaths)
+            });
+            totalPoints += points;
+
+            if (players.Count >= MaxPlayersPerRun)
+            {
+                break;
+            }
+        }
+
+        if (players.Count == 0)
+        {
+            error = "No human players found for submission payload.";
+            return false;
+        }
+
+        float runStart = gameManager.RunStartedAtServerTime > 0f
+            ? gameManager.RunStartedAtServerTime
+            : fallbackRunStartTime;
+
+        int durationSeconds = Mathf.RoundToInt(Mathf.Max(0f, Time.time - runStart));
+
+        payload = new ZombieRunSubmitDto
+        {
+            version = NormalizeVersion(ZombieLeaderboardVersionResolver.ResolveGameVersion()),
+            playerCount = players.Count,
+            wavesSurvived = Mathf.Max(0, gameManager.CurrentWave),
+            duration = durationSeconds,
+            totalPoints = Mathf.Max(0, totalPoints),
+            players = players
+        };
+
+        return true;
+    }
+
+    private async Task ProcessQueueAsync()
+    {
+        if (isProcessingQueue)
+        {
+            return;
+        }
+
+        isProcessingQueue = true;
+
+        try
+        {
+            while (pendingSubmissions.Count > 0)
+            {
+                if (cts == null || cts.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                var item = pendingSubmissions.Dequeue();
+                bool delivered = false;
+                int attempt = 0;
+
+                while (!delivered && attempt <= maxRetryAttempts)
+                {
+                    if (cts.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    attempt++;
+                    var result = await SubmitZombieRunAsync(item.Payload, cts.Token);
+                    if (result.Success)
+                    {
+                        delivered = true;
+                        Debug.Log($"[{nameof(ZombieLeaderboardRunSubmitter)}] Submitted run #{item.SubmissionId} (runSeq={item.RunSequence}, reason={item.EndReason}).", this);
+                        break;
+                    }
+
+                    bool canRetry = result.IsTransient && attempt <= maxRetryAttempts;
+                    if (!canRetry)
+                    {
+                        Debug.LogWarning($"[{nameof(ZombieLeaderboardRunSubmitter)}] Dropped run #{item.SubmissionId} after {attempt} attempt(s). Status={result.Status}, Error={result.Error}", this);
+                        break;
+                    }
+
+                    float retryDelay = initialRetryDelaySeconds * Mathf.Pow(2f, attempt - 1);
+                    retryDelay += UnityEngine.Random.Range(0f, 0.5f);
+                    int retryDelayMs = Mathf.RoundToInt(Mathf.Max(0.1f, retryDelay) * 1000f);
+
+                    Debug.LogWarning($"[{nameof(ZombieLeaderboardRunSubmitter)}] Retry {attempt}/{maxRetryAttempts} for run #{item.SubmissionId} in {retryDelay:0.0}s. Status={result.Status}, Error={result.Error}", this);
+                    await Task.Delay(retryDelayMs, cts.Token);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            isProcessingQueue = false;
+        }
+    }
+
+    private async Task<SubmissionResult> SubmitZombieRunAsync(ZombieRunSubmitDto payload, CancellationToken token)
+    {
+        string endpoint = $"{TrimSlash(baseUrl)}/runs/zombie";
+
+        UnityWebRequest request = null;
+        CancellationTokenRegistration cancellationRegistration = default;
+
+        try
+        {
+            string json = JsonUtility.ToJson(payload);
+            byte[] bodyBytes = Encoding.UTF8.GetBytes(json);
+
+            request = new UnityWebRequest(endpoint, UnityWebRequest.kHttpVerbPOST);
+            request.uploadHandler = new UploadHandlerRaw(bodyBytes);
+            request.downloadHandler = new DownloadHandlerBuffer();
+            request.SetRequestHeader("Content-Type", "application/json");
+            request.timeout = Mathf.Max(1, timeoutSeconds);
+
+            if (token.CanBeCanceled)
+            {
+                cancellationRegistration = token.Register(() =>
+                {
+                    try
+                    {
+                        if (request != null && !request.isDone)
+                        {
+                            request.Abort();
+                        }
+                    }
+                    catch
+                    {
+                    }
+                });
+            }
+
+            var operation = request.SendWebRequest();
+            await WaitForRequestAsync(operation, token);
+
+            long status = request.responseCode;
+            bool success = status >= 200 && status < 300;
+            if (success)
+            {
+                return SubmissionResult.Ok(status);
+            }
+
+            bool transient = status == 0
+                || (status >= 500 && status < 600)
+                || request.result == UnityWebRequest.Result.ConnectionError;
+
+            string responseBody = request.downloadHandler != null ? request.downloadHandler.text : string.Empty;
+            string error = BuildHttpError(request.error, responseBody);
+
+            if (!string.IsNullOrWhiteSpace(responseBody))
+            {
+                Debug.LogWarning($"[{nameof(ZombieLeaderboardRunSubmitter)}] Server rejected payload with status {status}. Body={Truncate(responseBody, 800)} Payload={JsonUtility.ToJson(payload)}", this);
+            }
+
+            return SubmissionResult.Fail(status, error, transient);
+        }
+        catch (OperationCanceledException)
+        {
+            return SubmissionResult.Fail(-1, "Submission cancelled.", true);
+        }
+        catch (Exception ex)
+        {
+            return SubmissionResult.Fail(0, ex.Message, true);
+        }
+        finally
+        {
+            try
+            {
+                cancellationRegistration.Dispose();
+            }
+            catch
+            {
+            }
+
+            if (request != null)
+            {
+                request.Dispose();
+            }
+        }
+    }
+
+    private static Task WaitForRequestAsync(UnityWebRequestAsyncOperation operation, CancellationToken token)
+    {
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        operation.completed += _ => tcs.TrySetResult(true);
+        if (token.CanBeCanceled)
+        {
+            token.Register(() => tcs.TrySetCanceled(token));
+        }
+
+        return tcs.Task;
+    }
+
+    private static string TrimSlash(string value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? DefaultBaseUrl : value.TrimEnd('/');
+    }
+
+    private static string SanitizeNickname(string rawNickname, int connectionId)
+    {
+        string nickname = string.IsNullOrWhiteSpace(rawNickname) ? $"Player{connectionId}" : rawNickname.Trim();
+        nickname = UnsafeNicknameChars.Replace(nickname, string.Empty);
+
+        if (string.IsNullOrWhiteSpace(nickname))
+        {
+            nickname = $"Player{connectionId}";
+        }
+
+        return nickname;
+    }
+
+    private static string NormalizeVersion(string rawVersion)
+    {
+        if (string.IsNullOrWhiteSpace(rawVersion))
+        {
+            return "0.0.0";
+        }
+
+        string sanitized = rawVersion.Trim();
+        if (sanitized.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+        {
+            sanitized = sanitized.Substring(1);
+        }
+
+        var match = Regex.Match(sanitized, "\\d+\\.\\d+\\.\\d+");
+        return match.Success ? match.Value : "0.0.0";
+    }
+
+    private static string BuildHttpError(string requestError, string responseBody)
+    {
+        string left = string.IsNullOrWhiteSpace(requestError) ? string.Empty : requestError.Trim();
+        string right = string.IsNullOrWhiteSpace(responseBody) ? string.Empty : Truncate(responseBody, 800).Trim();
+
+        if (!string.IsNullOrWhiteSpace(left) && !string.IsNullOrWhiteSpace(right))
+        {
+            return $"{left} | {right}";
+        }
+
+        return !string.IsNullOrWhiteSpace(left) ? left : (!string.IsNullOrWhiteSpace(right) ? right : "Request failed.");
+    }
+
+    private static string Truncate(string value, int maxLen)
+    {
+        if (string.IsNullOrEmpty(value) || maxLen <= 0)
+        {
+            return string.Empty;
+        }
+
+        return value.Length <= maxLen ? value : value.Substring(0, maxLen);
+    }
+
+    private struct QueuedSubmission
+    {
+        public int SubmissionId;
+        public int RunSequence;
+        public ZombieRunEndReason EndReason;
+        public ZombieRunSubmitDto Payload;
+    }
+
+    private struct SubmissionResult
+    {
+        public bool Success;
+        public long Status;
+        public string Error;
+        public bool IsTransient;
+
+        public static SubmissionResult Ok(long status)
+        {
+            return new SubmissionResult
+            {
+                Success = true,
+                Status = status,
+                Error = string.Empty,
+                IsTransient = false
+            };
+        }
+
+        public static SubmissionResult Fail(long status, string error, bool isTransient)
+        {
+            return new SubmissionResult
+            {
+                Success = false,
+                Status = status,
+                Error = string.IsNullOrWhiteSpace(error) ? "Request failed." : error,
+                IsTransient = isTransient
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Leaderboard/ZombieLeaderboardRunSubmitter.cs.meta
+++ b/Assets/Scripts/Leaderboard/ZombieLeaderboardRunSubmitter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 07f0a59e01c9dbe40bd66ea01143e25f

--- a/Assets/Scripts/ZombieGameManager.cs
+++ b/Assets/Scripts/ZombieGameManager.cs
@@ -66,6 +66,7 @@ public class ZombieGameManager : NetworkBehaviour
     private Coroutine autoReturnToLobbyCoroutine;
     private float nextLeaderboardReconcileAt = 0f;
     private bool returnToLobbyRequested = false;
+    private float runStartedAtServerTime = 0f;
 
     public int CurrentWave => currentWave;
     public bool IsGamePaused => isGamePaused;
@@ -73,6 +74,7 @@ public class ZombieGameManager : NetworkBehaviour
     public bool IsGameOver => isGameOver;
     public bool IsAutoReturnToLobbyEnabled => autoReturnToLobbyEnabled;
     public float ReturnToLobbyCountdownSeconds => returnToLobbyCountdownSeconds;
+    public float RunStartedAtServerTime => runStartedAtServerTime;
     public int CurrentWaveTotalCount => currentWaveTotalCount;
     public int CurrentWaveKilledCount => currentWaveKilledCount;
     public float CurrentWaveKilledPercent => currentWaveTotalCount <= 0
@@ -206,6 +208,7 @@ public class ZombieGameManager : NetworkBehaviour
         trackedZombieNetIds.Clear();
         zombiesAlive = 0;
         queuedSpawnCount = 0;
+        runStartedAtServerTime = Time.time;
 
         EventManager.Instance.Publish(new ZombieGameOverEvent(false));
         EventManager.Instance.Publish(new ZombieReturnToLobbyCountdownEvent(false, 0f));
@@ -233,6 +236,9 @@ public class ZombieGameManager : NetworkBehaviour
         {
             return;
         }
+
+        EventManager.Instance.Publish(new ZombieRunEndedEvent(
+            isGameOver ? ZombieRunEndReason.ReturnToLobbyAfterGameOver : ZombieRunEndReason.HostEndedEarly));
 
         returnToLobbyRequested = true;
 
@@ -1002,6 +1008,7 @@ public class ZombieGameManager : NetworkBehaviour
 
         OnGameOverStateChanged(true);
         EventManager.Instance.Publish(new ZombieGameOverEvent(true));
+        EventManager.Instance.Publish(new ZombieRunEndedEvent(ZombieRunEndReason.AllPlayersDead));
 
         if (isServerOnly && autoReturnToLobbyCoroutine == null)
         {

--- a/Assets/Ui/Components/InGameMenu/InGameMenuController.cs
+++ b/Assets/Ui/Components/InGameMenu/InGameMenuController.cs
@@ -124,6 +124,13 @@ public class InGameMenuController : MonoBehaviour
         // Ensure menu is closed and input unblocked before switching scenes
         CloseMenu();
 
+        // In zombie mode, use the manager flow so run-end side effects stay centralized.
+        if (NetworkServer.active && ZombieGameManager.Singleton != null)
+        {
+            ZombieGameManager.Singleton.ServerReturnToLobby();
+            return;
+        }
+
         // Use NetworkRoomManager to properly return to lobby scene
         if (NetworkManager.singleton is NetworkRoomManager roomManager)
         {


### PR DESCRIPTION
- Add ZombieLeaderboardModels with DTOs for run and player data and version to derive game version.
- Implement ZombieLeaderboardRunSubmitter MonoBehaviour to build and post run submissions with retry, timeout, and sanitization logic.
- Persist meta files for leaderboard assets.
- Track runStartedAtTime in ZombieGameManager, expose it via a property, initialize it when a run starts, and publish ZombieRunEndedEvent on various run end paths so run submission can react centrally.
- Route in-game menu "Return to Lobby" via ZombieManager when the server is active to keep run-end side centralized.

These changes enable reliable run submission to leaderboardensure run lifecycle events timestamps are captured server-side.