### PR TITLE
feat(skills): split damage fields into typed componentsConvertolithic "amount" into explicit damage type fields forBlastDamageFor50 and OblivionBeamSkillEffectDamage. thesingle amount property with structured flags and per-type values:

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/IceBlast/IceBlastDamageFor50.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/IceBlast/IceBlastDamageFor50.asset
@@ -12,4 +12,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 626adc8cd51944bfda2721e51e8e7645, type: 3}
   m_Name: IceBlastDamageFor50
   m_EditorClassIdentifier: 
-  amount: 50
+  countsAsCasted: 0
+  enabled: 1
+  physicalMode: 0
+  physicalAmount: 0
+  physicalAttackPowerScaling: 0
+  physicalAbilityPowerScaling: 0
+  magicMode: 0
+  magicAmount: 50
+  magicAttackPowerScaling: 0
+  magicAbilityPowerScaling: 15
+  trueDamageMode: 0
+  trueDamageAmount: 0
+  trueDamageAttackPowerScaling: 0
+  trueDamageAbilityPowerScaling: 0

--- a/Assets/Resources/ScriptableObjects/Skills/OblivionBeam/OblivionBeamSkillEffectDamage.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/OblivionBeam/OblivionBeamSkillEffectDamage.asset
@@ -14,4 +14,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   countsAsCasted: 0
   enabled: 1
-  amount: 75
+  physicalMode: 0
+  physicalAmount: 0
+  physicalAttackPowerScaling: 0
+  physicalAbilityPowerScaling: 0
+  magicMode: 0
+  magicAmount: 75
+  magicAttackPowerScaling: 0
+  magicAbilityPowerScaling: 20
+  trueDamageMode: 0
+  trueDamageAmount: 0
+  trueDamageAttackPowerScaling: 0
+  trueDamageAbilityPowerScaling: 0


### PR DESCRIPTION
countsAsCasted, enabled, physicalMode/Amount/Scaling, magicMode/
Amount/Scaling and trueDamageMode/Amount/Scaling. Set magicAmount andmagicAbilityPowerScaling for skill (50/15 for Ice,75/20 forlivionBeam) and the unused physical/true components.

 clarifies damage semantics, enables mixed damage and scaling, andpares data model for future features like conditional damagemodes and UI-driven editing.