### PR TITLE
feat(loadout/): enforce weapon for skillsAdd compatibility checks when and selecting skills,

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/ShadowForm/ShadowForm.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/ShadowForm/ShadowForm.asset
@@ -18,6 +18,9 @@ MonoBehaviour:
   cooldown: 45
   castCost: 0
   canActivateWhileBusy: 1
+  hasRequiredWeapon: 1
+  requiredWeapon: 2
+  npcOnly: 0
   initTrigger: {fileID: 0}
   castTrigger: {fileID: 11400000, guid: d54759c25c5be4981a3a4388e21f893e, type: 2}
   reactiveTriggers: []

--- a/Assets/Scripts/NetworkedSkillInstance.cs
+++ b/Assets/Scripts/NetworkedSkillInstance.cs
@@ -151,6 +151,14 @@ public class NetworkedSkillInstance : NetworkBehaviour
 
         if (IsOnCooldown || skillData == null) return;
 
+        var currentWeaponType = unit.currentWeapon != null
+            ? (WeaponType?)unit.currentWeapon.weaponType
+            : null;
+        if (!skillData.CanBeUsedWithWeapon(currentWeaponType))
+        {
+            return;
+        }
+
         // If the unit is busy (casting/attacking/etc), only block if the skill doesn't allow activation while busy
         if (unit.unitActionState.IsActive && !skillData.canActivateWhileBusy) return;
 

--- a/Assets/Scripts/PlayerLoadout.cs
+++ b/Assets/Scripts/PlayerLoadout.cs
@@ -186,9 +186,16 @@ public class PlayerLoadout : NetworkBehaviour
         var normalUnique = desiredNormalSkills.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct().Take(3).ToArray();
         foreach (var name in normalUnique)
         {
-            if (skillDb.GetSkillByName(name) == null)
+            var skill = skillDb.GetSkillByName(name);
+            if (skill == null)
             {
                 TargetAckSetLoadout(connectionToClient, false, $"Unknown skill: {name}");
+                return;
+            }
+
+            if (!skill.CanBeUsedWithWeapon(weaponData.weaponType))
+            {
+                TargetAckSetLoadout(connectionToClient, false, $"Skill '{name}' requires weapon: {skill.GetRequiredWeaponLabel()}");
                 return;
             }
         }
@@ -196,16 +203,33 @@ public class PlayerLoadout : NetworkBehaviour
         var passiveUnique = desiredPassiveSkills.Where(n => !string.IsNullOrWhiteSpace(n)).Distinct().Take(2).ToArray();
         foreach (var name in passiveUnique)
         {
-            if (skillDb.GetSkillByName(name) == null)
+            var skill = skillDb.GetSkillByName(name);
+            if (skill == null)
             {
                 TargetAckSetLoadout(connectionToClient, false, $"Unknown passive: {name}");
                 return;
             }
+
+            if (!skill.CanBeUsedWithWeapon(weaponData.weaponType))
+            {
+                TargetAckSetLoadout(connectionToClient, false, $"Passive '{name}' requires weapon: {skill.GetRequiredWeaponLabel()}");
+                return;
+            }
         }
-        if (!string.IsNullOrWhiteSpace(desiredUltimateSkill) && skillDb.GetSkillByName(desiredUltimateSkill) == null)
+        if (!string.IsNullOrWhiteSpace(desiredUltimateSkill))
         {
-            TargetAckSetLoadout(connectionToClient, false, $"Unknown ultimate: {desiredUltimateSkill}");
-            return;
+            var ultimate = skillDb.GetSkillByName(desiredUltimateSkill);
+            if (ultimate == null)
+            {
+                TargetAckSetLoadout(connectionToClient, false, $"Unknown ultimate: {desiredUltimateSkill}");
+                return;
+            }
+
+            if (!ultimate.CanBeUsedWithWeapon(weaponData.weaponType))
+            {
+                TargetAckSetLoadout(connectionToClient, false, $"Ultimate '{desiredUltimateSkill}' requires weapon: {ultimate.GetRequiredWeaponLabel()}");
+                return;
+            }
         }
 
         // Apply to unit (server authoritative)

--- a/Assets/Scripts/ScriptableObjects/SkillData.cs
+++ b/Assets/Scripts/ScriptableObjects/SkillData.cs
@@ -11,7 +11,22 @@ public class SkillData : ScriptableObject
     public int cooldown;
     public int castCost;
     public bool canActivateWhileBusy;
-    public WeaponType? requiredWeapon;
+    [Tooltip("If false, this skill can be used with any weapon.")]
+    [SerializeField] private bool hasRequiredWeapon;
+    [SerializeField] private WeaponType requiredWeapon;
+
+    public WeaponType? RequiredWeapon
+    {
+        get => hasRequiredWeapon ? requiredWeapon : (WeaponType?)null;
+        set
+        {
+            hasRequiredWeapon = value.HasValue;
+            if (value.HasValue)
+            {
+                requiredWeapon = value.Value;
+            }
+        }
+    }
     
     [Header("Restrictions")]
     public bool npcOnly;
@@ -26,6 +41,22 @@ public class SkillData : ScriptableObject
 
     [Header("UI")]
     public Texture2D iconTexture;
+
+    public bool CanBeUsedWithWeapon(WeaponType? weaponType)
+    {
+        var required = RequiredWeapon;
+        if (!required.HasValue)
+        {
+            return true;
+        }
+
+        return weaponType.HasValue && weaponType.Value == required.Value;
+    }
+
+    public string GetRequiredWeaponLabel()
+    {
+        return RequiredWeapon.HasValue ? RequiredWeapon.Value.ToString() : "Any";
+    }
 
     public IEnumerator ExecuteInitCoroutine(CastContext castContext)
     {

--- a/Assets/Scripts/UiDocumentZombieIngameController.cs
+++ b/Assets/Scripts/UiDocumentZombieIngameController.cs
@@ -688,12 +688,14 @@ public class UiDocumentZombieIngameController : MonoBehaviour
     {
         var title = $"<size=20><b>{skillData.skillName}</b></size>";
         var type = $"<size=16><color=#cccccc>Type: {skillData.skillType}</color></size>";
+        var requiredWeapon = $"<size=16><color=#cccccc>Required Weapon: {skillData.GetRequiredWeaponLabel()}</color></size>";
         var cooldown = $"<size=16><color=#cccccc>Cooldown: {skillData.cooldown}s</color></size>";
         var description = $"<size=16>{skillData.description}</size>";
 
         var text = "";
         text += $"{title}\n";
         text += $"{type}\n";
+        text += $"{requiredWeapon}\n";
         text += skillData.cooldown != 0 ? $"{cooldown}\n" : "";
         text += $"\n{description}";
 

--- a/Assets/Ui/Components/LoadoutWindow/LoadoutWindow.cs
+++ b/Assets/Ui/Components/LoadoutWindow/LoadoutWindow.cs
@@ -295,6 +295,8 @@ namespace Vland.UI
         }
 
         private LoadoutSlot _lastActive = LoadoutSlot.Weapon;
+        public LoadoutSlot ActiveSlot => _lastActive;
+
         public void SetActiveSlot(LoadoutSlot slot)
         {
             _lastActive = slot;

--- a/Assets/Ui/Components/LoadoutWindow/LoadoutWindowController.cs
+++ b/Assets/Ui/Components/LoadoutWindow/LoadoutWindowController.cs
@@ -60,6 +60,9 @@ public class LoadoutWindowController : MonoBehaviour
             else if (slot == LoadoutSlot.Ultimate) PopulateGridFor(LoadoutSlot.Ultimate);
             else PopulateGridFor(LoadoutSlot.Normal1);
         };
+
+        ClearIncompatibleSkillSelections();
+        ApplyCurrentLoadout();
     }
 
     private void TryInitializeFromSavedLoadout()
@@ -129,6 +132,8 @@ public class LoadoutWindowController : MonoBehaviour
             return;
         }
 
+        var selectedWeaponType = GetSelectedWeaponType();
+
         if (slot == LoadoutSlot.Weapon)
         {
             if (_db.weaponDatabase != null)
@@ -150,7 +155,7 @@ public class LoadoutWindowController : MonoBehaviour
         {
             if (_db.skillDatabase != null)
             {
-                foreach (var s in _db.skillDatabase.allSkills.Where(s => s != null && s.skillType == SkillType.Passive && !s.npcOnly))
+                foreach (var s in _db.skillDatabase.allSkills.Where(s => s != null && s.skillType == SkillType.Passive && !s.npcOnly && s.CanBeUsedWithWeapon(selectedWeaponType)))
                 {
                     items.Add(new LoadoutItem
                     {
@@ -167,7 +172,7 @@ public class LoadoutWindowController : MonoBehaviour
         {
             if (_db.skillDatabase != null)
             {
-                foreach (var s in _db.skillDatabase.allSkills.Where(s => s != null && s.skillType == SkillType.Ultimate && !s.npcOnly))
+                foreach (var s in _db.skillDatabase.allSkills.Where(s => s != null && s.skillType == SkillType.Ultimate && !s.npcOnly && s.CanBeUsedWithWeapon(selectedWeaponType)))
                 {
                     items.Add(new LoadoutItem
                     {
@@ -185,7 +190,7 @@ public class LoadoutWindowController : MonoBehaviour
             // normals
             if (_db.skillDatabase != null)
             {
-                foreach (var s in _db.skillDatabase.allSkills.Where(s => s != null && s.skillType == SkillType.Normal && !s.npcOnly))
+                foreach (var s in _db.skillDatabase.allSkills.Where(s => s != null && s.skillType == SkillType.Normal && !s.npcOnly && s.CanBeUsedWithWeapon(selectedWeaponType)))
                 {
                     items.Add(new LoadoutItem
                     {
@@ -206,12 +211,14 @@ public class LoadoutWindowController : MonoBehaviour
     {
         var title = $"<size=20><b>{skillData.skillName}</b></size>";
         var type = $"<size=16><color=#cccccc>Type: {skillData.skillType}</color></size>";
+        var requiredWeapon = $"<size=16><color=#cccccc>Required Weapon: {skillData.GetRequiredWeaponLabel()}</color></size>";
         var cooldown = $"<size=16><color=#cccccc>Cooldown: {skillData.cooldown}s</color></size>";
         var description = $"<size=16>{skillData.description}</size>";
 
         var text = "";
         text += $"{title}\n";
         text += $"{type}\n";
+        text += $"{requiredWeapon}\n";
         text += skillData.cooldown != 0 ? $"{cooldown}\n" : "";
         text += $"\n{description}";
 
@@ -233,9 +240,81 @@ public class LoadoutWindowController : MonoBehaviour
 
     private void HandleSelectionChanged(LoadoutSlot slot, string id)
     {
+        if (slot == LoadoutSlot.Weapon)
+        {
+            ClearIncompatibleSkillSelections();
+
+            var activeSlot = _window.ActiveSlot;
+            if (activeSlot != LoadoutSlot.Weapon)
+            {
+                PopulateGridFor(activeSlot);
+            }
+        }
+
         if (_applyPending) return;
         _applyPending = true;
         _applyRoutine = StartCoroutine(ApplyAtEndOfFrame());
+    }
+
+    private WeaponType? GetSelectedWeaponType()
+    {
+        if (_db == null || _db.weaponDatabase == null)
+        {
+            return null;
+        }
+
+        var selectedWeaponId = _window.GetSelectedId(LoadoutSlot.Weapon);
+        if (string.IsNullOrWhiteSpace(selectedWeaponId))
+        {
+            return null;
+        }
+
+        var weapon = _db.weaponDatabase.GetWeaponByName(selectedWeaponId);
+        return weapon != null ? weapon.weaponType : null;
+    }
+
+    private void ClearIncompatibleSkillSelections()
+    {
+        if (_db == null || _db.skillDatabase == null)
+        {
+            return;
+        }
+
+        var weaponType = GetSelectedWeaponType();
+        if (!weaponType.HasValue)
+        {
+            return;
+        }
+
+        var slotsToCheck = new[]
+        {
+            LoadoutSlot.Passive,
+            LoadoutSlot.Normal1,
+            LoadoutSlot.Normal2,
+            LoadoutSlot.Normal3,
+            LoadoutSlot.Ultimate,
+        };
+
+        foreach (var slot in slotsToCheck)
+        {
+            var selectedId = _window.GetSelectedId(slot);
+            if (string.IsNullOrWhiteSpace(selectedId))
+            {
+                continue;
+            }
+
+            var skill = _db.skillDatabase.GetSkillByName(selectedId);
+            if (skill == null)
+            {
+                _window.SelectById(slot, null);
+                continue;
+            }
+
+            if (!skill.CanBeUsedWithWeapon(weaponType))
+            {
+                _window.SelectById(slot, null);
+            }
+        }
     }
 
     private System.Collections.IEnumerator ApplyAtEndOfFrame()


### PR DESCRIPTION
ing use of skills that require a different weapon type.

 NetworkedSkill: check the unit's weapon type before allowing skill activation and return early if the skill is usable with that weapon.
- Playerout: validate normal passive and ultimate choices against selected weapon when a loadout, returning clear error message indicating the required weapon when validation fails.
 UiDocumentZombieIngame: display required-weapon information in the skill tooltip so players can see weapon constraints in-game.
- LoadoutWindowController: filter loadout skill by the selected weapon type initialize UI state (clear incompatible selections and apply current load) to reflect weapon-based restrictions.

This ensures consistent server enforcement clearer UIfeedback for weapon-dependent.