### PR TITLE
fix(ui): correct ofout slots in UIAdjust the LoadoutWindow slot bar construction and index mapping ensure the displayed slots match their underlying indices.

### DIFF
--- a/Assets/Ui/Components/LoadoutWindow/LoadoutWindow.cs
+++ b/Assets/Ui/Components/LoadoutWindow/LoadoutWindow.cs
@@ -131,8 +131,8 @@ namespace Vland.UI
         private void BuildSlotBar()
         {
             _slotsBar.Clear();
-            AddSlot(LoadoutSlot.Passive, "Passive");
             AddSlot(LoadoutSlot.Weapon, "Weapon");
+            AddSlot(LoadoutSlot.Passive, "Passive");
             AddSlot(LoadoutSlot.Normal1, "Skill 1");
             AddSlot(LoadoutSlot.Normal2, "Skill 2");
             AddSlot(LoadoutSlot.Normal3, "Skill 3");
@@ -345,8 +345,8 @@ namespace Vland.UI
             // slotsBar children map order: 0 Weapon,1 Passive,2 N1,3 N2,4 N3,5 Ult
             int idx = slot switch
             {
-                LoadoutSlot.Passive => 0,
-                LoadoutSlot.Weapon => 1,
+                LoadoutSlot.Weapon => 0,
+                LoadoutSlot.Passive => 1,
                 LoadoutSlot.Normal1 => 2,
                 LoadoutSlot.Normal2 => 3,
                 LoadoutSlot.Normal3 => 4,


### PR DESCRIPTION
- Move Passive slot below Weapon inSlot so the visual order becomes Weapon, Passive Skill1, Skill2, Skill3- Update the-to-index switch so Weapon maps to index0 and maps to index1, aligning indices with the UI order.

This prevents mismatches between slot positions andfunctional indices, fixing incorrect slot behavior and selection.