### PR TITLE
feat(skills): specific weapons forCleave andaggerFanAdd weapon requirements to skill so must equipthe correct weapon type to use skills. EchoCleave now setshasRequiredWeapon requiredWeapon to1; DaggerFan them to1 respectively.

### DIFF
--- a/Assets/Resources/ScriptableObjects/Skills/DaggerFan/DaggerFan.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/DaggerFan/DaggerFan.asset
@@ -21,6 +21,8 @@ MonoBehaviour:
   cooldown: 12
   castCost: 0
   canActivateWhileBusy: 0
+  hasRequiredWeapon: 1
+  requiredWeapon: 2
   npcOnly: 0
   initTrigger: {fileID: 0}
   castTrigger: {fileID: 11400000, guid: ca38c74b55dede649bd5c309f7d50be6, type: 2}

--- a/Assets/Resources/ScriptableObjects/Skills/EchoCleave/EchoCleave.asset
+++ b/Assets/Resources/ScriptableObjects/Skills/EchoCleave/EchoCleave.asset
@@ -18,6 +18,8 @@ MonoBehaviour:
   cooldown: 8
   castCost: 0
   canActivateWhileBusy: 0
+  hasRequiredWeapon: 1
+  requiredWeapon: 1
   npcOnly: 0
   initTrigger: {fileID: 0}
   castTrigger: {fileID: 11400000, guid: 10479d16e33339242ab5d1e4f7164c05, type: 2}


### PR DESCRIPTION
This unintended activation with wrong weapons and ensuresskill behavior aligns with design intent for weapon- abilities.